### PR TITLE
Arduino Due native USB fix

### DIFF
--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -417,8 +417,8 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 						raise FlashException("bossac error: " + output[output.find(self.AVRDUDE_ERROR) + len(self.AVRDUDE_ERROR):].strip())
 
 			if p.returncode == 0:
-				self._send_status("progress", subtype="wait_at_end")
-				time.sleep(10) # wait for serial port to wake up
+				# self._send_status("progress", subtype="wait_at_end")
+				# time.sleep(10) # wait for serial port to wake up
 				return True
 			else:
 				raise FlashException("bossac returned code {returncode}".format(returncode=p.returncode))

--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -372,7 +372,7 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 		bossac_command = [bossac_path, "-i", "-p", printer_port, "-e", "-w"]
 		if not bossac_disableverify:
 			bossac_command += ["-v"]
-		bossac_command += ["-b", firmware, "-R"]
+		bossac_command += ["-b", firmware, "-R", "&&", "sleep", "10"]
 
 		self._logger.info(u"Attempting to reset the board to SAM-BA")
 		if not self._reset_1200(printer_port):
@@ -417,8 +417,6 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 						raise FlashException("bossac error: " + output[output.find(self.AVRDUDE_ERROR) + len(self.AVRDUDE_ERROR):].strip())
 
 			if p.returncode == 0:
-				# self._send_status("progress", subtype="wait_at_end")
-				# time.sleep(10) # wait for serial port to wake up
 				return True
 			else:
 				raise FlashException("bossac returned code {returncode}".format(returncode=p.returncode))

--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -369,7 +369,7 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 
 		working_dir = os.path.dirname(bossac_path)
 
-		bossac_command = [bossac_path, "-i", "-p", printer_port, "-U", "false", "-e", "-w"]
+		bossac_command = [bossac_path, "-i", "-p", printer_port, "-e", "-w"]
 		if not bossac_disableverify:
 			bossac_command += ["-v"]
 		bossac_command += ["-b", firmware, "-R"]

--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -417,7 +417,7 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 						raise FlashException("bossac error: " + output[output.find(self.AVRDUDE_ERROR) + len(self.AVRDUDE_ERROR):].strip())
 
 			if p.returncode == 0:
-				time.sleep(15)
+				time.sleep(20)
 				return True
 			else:
 				raise FlashException("bossac returned code {returncode}".format(returncode=p.returncode))

--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -456,14 +456,15 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 		assert(printer_port is not None)
 		self._logger.info(u"Toggling '{port}' at 1200bps".format(port=printer_port))
 		try:
-			ser = serial.Serial(port=printer_port, \
-								baudrate=1200, \
-								parity=serial.PARITY_NONE, \
-								stopbits=serial.STOPBITS_ONE , \
-								bytesize=serial.EIGHTBITS, \
-								timeout=2000)
+			os.system("stty -F "+printer_port+" speed 1200")
+			# ser = serial.Serial(port=printer_port, \
+			# 					baudrate=1200, \
+			# 					parity=serial.PARITY_NONE, \
+			# 					stopbits=serial.STOPBITS_ONE , \
+			# 					bytesize=serial.EIGHTBITS, \
+			# 					timeout=2000)
 			time.sleep(5)
-			ser.close()
+			# ser.close()
 		except SerialException as ex:
 			self._logger.exception(u"Board reset failed: {error}".format(error=str(ex)))
 			self._send_status("flasherror", message="Board reset failed")

--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -417,6 +417,8 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 						raise FlashException("bossac error: " + output[output.find(self.AVRDUDE_ERROR) + len(self.AVRDUDE_ERROR):].strip())
 
 			if p.returncode == 0:
+				self._send_status("progress", subtype="wait_at_end")
+				time.sleep(10) # wait for serial port to wake up
 				return True
 			else:
 				raise FlashException("bossac returned code {returncode}".format(returncode=p.returncode))
@@ -457,15 +459,8 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 		self._logger.info(u"Toggling '{port}' at 1200bps".format(port=printer_port))
 		try:
 			os.system("stty -F "+printer_port+" speed 1200")
-			# ser = serial.Serial(port=printer_port, \
-			# 					baudrate=1200, \
-			# 					parity=serial.PARITY_NONE, \
-			# 					stopbits=serial.STOPBITS_ONE , \
-			# 					bytesize=serial.EIGHTBITS, \
-			# 					timeout=2000)
 			time.sleep(5)
-			# ser.close()
-		except SerialException as ex:
+		except:
 			self._logger.exception(u"Board reset failed: {error}".format(error=str(ex)))
 			self._send_status("flasherror", message="Board reset failed")
 			return False

--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -417,8 +417,6 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 						raise FlashException("bossac error: " + output[output.find(self.AVRDUDE_ERROR) + len(self.AVRDUDE_ERROR):].strip())
 
 			if p.returncode == 0:
-				self._logger.info(u"Waiting for port to wake up...")
-				self._send_status("progress", subtype="wake_up")
 				time.sleep(20)
 				return True
 			else:

--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -372,7 +372,7 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 		bossac_command = [bossac_path, "-i", "-p", printer_port, "-e", "-w"]
 		if not bossac_disableverify:
 			bossac_command += ["-v"]
-		bossac_command += ["-b", firmware, "-R", "&&", "sleep", "10"]
+		bossac_command += ["-b", firmware, "-R"]
 
 		self._logger.info(u"Attempting to reset the board to SAM-BA")
 		if not self._reset_1200(printer_port):
@@ -417,6 +417,7 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 						raise FlashException("bossac error: " + output[output.find(self.AVRDUDE_ERROR) + len(self.AVRDUDE_ERROR):].strip())
 
 			if p.returncode == 0:
+				time.sleep(15)
 				return True
 			else:
 				raise FlashException("bossac returned code {returncode}".format(returncode=p.returncode))

--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -417,6 +417,8 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 						raise FlashException("bossac error: " + output[output.find(self.AVRDUDE_ERROR) + len(self.AVRDUDE_ERROR):].strip())
 
 			if p.returncode == 0:
+				self._logger.info(u"Waiting for port to wake up...")
+				self._send_status("progress", subtype="wake_up")
 				time.sleep(20)
 				return True
 			else:

--- a/octoprint_firmwareupdater/static/js/firmwareupdater.js
+++ b/octoprint_firmwareupdater/static/js/firmwareupdater.js
@@ -310,6 +310,10 @@ $(function() {
                                     message = gettext("Reconnecting to printer...");
                                     break;
                                 }
+                                case "wake_up": {
+                                    message = gettext("Waiting for port to wake up...");
+                                    break;
+                                }
                             }
                         }
 

--- a/octoprint_firmwareupdater/static/js/firmwareupdater.js
+++ b/octoprint_firmwareupdater/static/js/firmwareupdater.js
@@ -306,10 +306,6 @@ $(function() {
                                     message = gettext("Verifying memory...");
                                     break;
                                 }
-                                case "wait_at_end": {
-                                    message = gettext("Waiting for serial port to wake up...");
-                                    break;
-                                }
                                 case "reconnecting": {
                                     message = gettext("Reconnecting to printer...");
                                     break;

--- a/octoprint_firmwareupdater/static/js/firmwareupdater.js
+++ b/octoprint_firmwareupdater/static/js/firmwareupdater.js
@@ -306,6 +306,10 @@ $(function() {
                                     message = gettext("Verifying memory...");
                                     break;
                                 }
+                                case "wait_at_end": {
+                                    message = gettext("Waiting for serial port to wake up...");
+                                    break;
+                                }
                                 case "reconnecting": {
                                     message = gettext("Reconnecting to printer...");
                                     break;

--- a/octoprint_firmwareupdater/static/js/firmwareupdater.js
+++ b/octoprint_firmwareupdater/static/js/firmwareupdater.js
@@ -310,10 +310,6 @@ $(function() {
                                     message = gettext("Reconnecting to printer...");
                                     break;
                                 }
-                                case "wake_up": {
-                                    message = gettext("Waiting for port to wake up...");
-                                    break;
-                                }
                             }
                         }
 


### PR DESCRIPTION
Passing "-U false" to bossac limits it to only working with the AVR USB port on an Arduino Due.  Removing it enables this plugin to work with the Arduino Due's native USB port without affecting compatibility if the AVR USB port is used instead.

One thing I've noticed with the native USB port is that while it allows for much faster transfers (I can flash a Marlin image over the native port in about 4 seconds, vs. over 30 seconds for the AVR port), it takes a while to wake back up after programming.  I've also added a 20-second delay after programming to allow the port to wake up so that OctoPrint doesn't get "port busy" errors when it reconnects afterward (if auto-connect is enabled).