### PR TITLE
Add support for stm32flash (FYSETC Cheetah)

### DIFF
--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -21,6 +21,7 @@ from octoprint_firmwareupdater.methods import avrdude
 from octoprint_firmwareupdater.methods import bossac
 from octoprint_firmwareupdater.methods import dfuprog
 from octoprint_firmwareupdater.methods import lpc1768
+from octoprint_firmwareupdater.methods import stm32flash
 
 class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
                             octoprint.plugin.TemplatePlugin,
@@ -39,8 +40,8 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 	def initialize(self):
 		# TODO: make method configurable via new plugin hook "octoprint.plugin.firmwareupdater.flash_methods",
 		# also include prechecks
-		self._flash_prechecks = dict(avrdude=avrdude._check_avrdude, bossac=bossac._check_bossac, dfuprogrammer=dfuprog._check_dfuprog, lpc1768=lpc1768._check_lpc1768)
-		self._flash_methods = dict(avrdude=avrdude._flash_avrdude, bossac=bossac._flash_bossac, dfuprogrammer=dfuprog._flash_dfuprog, lpc1768=lpc1768._flash_lpc1768)
+		self._flash_prechecks = dict(avrdude=avrdude._check_avrdude, bossac=bossac._check_bossac, dfuprogrammer=dfuprog._check_dfuprog, lpc1768=lpc1768._check_lpc1768, stm32flash=stm32flash._check_stm32flash)
+		self._flash_methods = dict(avrdude=avrdude._flash_avrdude, bossac=bossac._flash_bossac, dfuprogrammer=dfuprog._flash_dfuprog, lpc1768=lpc1768._flash_lpc1768, stm32flash=stm32flash._flash_stm32flash)
 
 		console_logging_handler = logging.handlers.RotatingFileHandler(self._settings.get_plugin_logfile_path(postfix="console"), maxBytes=2*1024*1024)
 		console_logging_handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
@@ -296,6 +297,15 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 			"dfuprog_avrmcu": None,
 			"dfuprog_commandline": "sudo {dfuprogrammer} {mcu} flash {firmware} --debug-level 10",
 			"dfuprog_erasecommandline": "sudo {dfuprogrammer} {mcu} erase --debug-level 10 --force",
+			"stm32flash_path": None,
+			"stm32flash_verify": True,
+			"stm32flash_boot0pin": "rts",
+			"stm32flash_boot0low": False,
+			"stm32flash_resetpin": "dtr",
+			"stm32flash_resetlow": True,
+			"stm32flash_execute": True,
+			"stm32flash_executeaddress": "0x8000000",
+			"stm32flash_reset": False,
 			"lpc1768_path": None,
 			"lpc1768_preflashreset": True,
 			"postflash_delay": "0",

--- a/octoprint_firmwareupdater/methods/stm32flash.py
+++ b/octoprint_firmwareupdater/methods/stm32flash.py
@@ -1,0 +1,116 @@
+import re
+import os
+import sarge
+
+def getGPIO(pin, low):
+    return ('-' if low else '') + pin
+
+def _check_stm32flash(self):
+    stm32flash_path = self._settings.get(["stm32flash_path"])
+
+    pattern = re.compile("^(\/[^\0/]+)+$")
+
+    if not pattern.match(stm32flash_path):
+        self._logger.error(u"Path to stm32flash is not valid: {path}".format(path=avrdude_path))
+        return False
+    elif not os.path.exists(stm32flash_path):
+        self._logger.error(u"Path to stm32flash does not exist: {path}".format(path=avrdude_path))
+        return False
+    elif not os.path.isfile(stm32flash_path):
+        self._logger.error(u"Path to stm32flash is not a file: {path}".format(path=avrdude_path))
+        return False
+    elif not os.access(stm32flash_path, os.X_OK):
+        self._logger.error(u"Path to stm32flash is not executable: {path}".format(path=avrdude_path))
+        return False
+    else:
+        return True
+
+def _flash_stm32flash(self, firmware=None, printer_port=None):
+    assert(firmware is not None)
+    assert(printer_port is not None)
+
+    stm32flash_path = self._settings.get(["stm32flash_path"])
+    stm32flash_verify = self._settings.get(["stm32flash_verify"])
+    stm32flash_boot0pin = self._settings.get(["stm32flash_boot0pin"])
+    stm32flash_boot0low = self._settings.get(["stm32flash_boot0low"])
+    stm32flash_resetpin = self._settings.get(["stm32flash_resetpin"])
+    stm32flash_resetlow = self._settings.get(["stm32flash_resetlow"])
+    stm32flash_execute = self._settings.get(["stm32flash_execute"])
+    stm32flash_executeaddress = self._settings.get(["stm32flash_executeaddress"])
+    stm32flash_reset = self._settings.get(["stm32flash_reset"])
+
+
+    working_dir = os.path.dirname(stm32flash_path)
+
+    stm32flash_args = [
+        stm32flash_path
+    ]
+    if (stm32flash_verify):
+        stm32flash_args.append('-v')
+
+    stm32flash_args.append('-i')
+    stm32flash_args.append(','.join([
+        getGPIO(stm32flash_boot0pin, stm32flash_boot0low),
+        getGPIO(stm32flash_resetpin, stm32flash_resetlow),
+        getGPIO(stm32flash_resetpin, not stm32flash_resetlow),
+        getGPIO(stm32flash_boot0pin, not stm32flash_boot0low),
+    ]))
+
+    if (stm32flash_execute):
+        stm32flash_args.append('-g')
+        stm32flash_args.append(stm32flash_executeaddress)
+
+    if (stm32flash_reset and not stm32flash_execute):
+        stm32flash_args.append('-R')
+
+    stm32flash_args.append('-w')
+    stm32flash_args.append(firmware)
+    stm32flash_args.append(printer_port)
+
+    stm32flash_command = ' '.join(stm32flash_args)
+
+    self._logger.info(u"Running '{}' in {}".format(stm32flash_command, working_dir))
+    self._console_logger.info(u"")
+    self._console_logger.info(stm32flash_command)
+
+    try:
+        p = sarge.run(stm32flash_command, cwd=working_dir, async=True, stdout=sarge.Capture(), stderr=sarge.Capture())
+        p.wait_events()
+
+        while p.returncode is None:
+            output = p.stderr.read(timeout=0.5)
+            if not output:
+                p.commands[0].poll()
+                continue
+
+            for line in output.split("\n"):
+                if line.endswith("\r"):
+                    line = line[:-1]
+                self._console_logger.info(u"> {}".format(line))
+
+            if "Writing" in output:
+                self._logger.info(u"Writing memory...")
+                self._send_status("progress", subtype="writing")
+            elif "Error" in output:
+                p.commands[0].kill()
+                p.close()
+                raise FlashException("stm32flash error " + output[output.find("Error") + len("Error"):].strip() + "'")
+
+        if p.returncode == 0:
+            return True
+        else:
+            raise FlashException("stm32flash returned code {returncode}".format(returncode=p.returncode))
+
+    except FlashException as ex:
+        self._logger.error(u"Flashing failed. {error}.".format(error=ex.reason))
+        self._send_status("flasherror", message=ex.reason)
+        return False
+    except:
+        self._logger.exception(u"Flashing failed. Unexpected error.")
+        self._send_status("flasherror")
+        return False
+
+class FlashException(Exception):
+	def __init__(self, reason, *args, **kwargs):
+		Exception.__init__(self, *args, **kwargs)
+		self.reason = reason

--- a/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
+++ b/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
@@ -91,6 +91,7 @@
                             <option value=bossac>bossac (Atmel SAM Family)</option>
                             <option value=dfuprogrammer>dfu-programmer (Atmel AVR with DFU)</option>
                             <option value=lpc1768>lpc1768 (LPC1768-based Boards)</option>
+                            <option value=stm32flash>stm32flash (STM32 built-in bootloader)</option>
                         </select>
                     </div>
                 </div>
@@ -195,9 +196,25 @@
                 </div>
                 <!-- end avrdude options -->
 
+                <!-- stm32flash options for STM32 MCUs -->
+                <div data-bind="visible: showStm32flashConfig">
+                    <div class="control-group" data-bind="css: {error: stm32flashPathBroken, success: stm32flashPathOk}">
+                        <label class="control-label">{{ _('Path to stm32flash') }}</label>
+                        <div class="controls">
+                            <div class="input-append">
+                                <input type="text" class="input-block-level" data-bind='value: configStm32flashPath, valueUpdate: "afterkeydown"'>
+                                <button class="btn" type="button" data-bind="click: testStm32flashPath, enable: configStm32flashPath, css: {disabled: !configStm32flashPath()}">{{ _('Test') }}</button>
+                            </div>
+                            <span class="help-block" data-bind="visible: stm32flashPathBroken() || stm32flashPathOk, text: stm32flashPathText"></span>
+                        </div>
+                    </div>
+                    <hr>
+                </div>
+                <!-- end stm32flash options -->
+
                 <!-- advanced options -->
 
-                <div data-bind="visible: !showAdvancedConfig() && (showAvrdudeConfig() || showBossacConfig() || showLpc1768Config() || showDfuConfig())">
+                <div data-bind="visible: !showAdvancedConfig() && (showAvrdudeConfig() || showBossacConfig() || showLpc1768Config() || showDfuConfig() || showStm32flashConfig())">
                     <label data-bind="click: toggleAdvancedConfig" >
                         <i class="icon-chevron-right icon-fixed-width"></i>Advanced Settings
                     </label>
@@ -327,12 +344,85 @@
                         </div>
                     </div>
                     <!-- End advanced bossac options-->
+
+                    <!-- Advanced stm32flash options -->
+                    <div data-bind="visible: showStm32flashConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Verify while writing') }}</label>
+                            <div class="controls">
+                                <div class="input">
+                                    <input type="checkbox" data-bind="checked: configStm32flashVerify">
+                                </div>
+                                <span class="help-block">{{ _('If checked memory will be verified as it get flashed. Otherwise memory won\'t be verified.') }}</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div data-bind="visible: showStm32flashConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('BOOT0 pin') }}</label>
+                            <div class="controls">
+                                <select data-bind="value: configStm32flashBoot0Pin">
+                                    <option value="dtr">DTR</option>
+                                    <option value="rts">RTS</option>
+                                </select>
+                                <label class="checkbox">
+                                    <input type="checkbox" data-bind="checked: configStm32flashBoot0Low"> Low
+                                </label>
+                                <span class="help-block">{{ _('Serial pin to enable bootloader') }}</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div data-bind="visible: showStm32flashConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Reset pin') }}</label>
+                            <div class="controls">
+                                <select data-bind="value: configStm32flashResetPin">
+                                    <option value="dtr">DTR</option>
+                                    <option value="rts">RTS</option>
+                                </select>
+                                <label class="checkbox">
+                                    <input type="checkbox" data-bind="checked: configStm32flashResetLow"> Low
+                                </label>
+                                <span class="help-block">{{ _('Serial pin to reset MCU') }}</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div data-bind="visible: showStm32flashConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Start execution') }}</label>
+                            <div class="controls">
+                                <label class="checkbox">
+                                    <input type="checkbox" data-bind="checked: configStm32flashExecute"> Enabled
+                                </label>
+                                <div class="input">
+                                    <input type="text" class="input-block-level" data-bind="value: configStm32flashExecuteAddress, enable: configStm32flashExecute, css: {disabled: !configStm32flashExecute()}">
+                                </div>
+                                <span class="help-block">{{ _('Address to execute after flashing.') }}</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div data-bind="visible: showStm32flashConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Reset after flashing') }}</label>
+                            <div class="controls">
+                                <div class="input">
+                                    <input type="checkbox" data-bind="checked: configStm32flashReset, disable: configStm32flashExecute">
+                                </div>
+                                <span class="help-block">{{ _('If checked MCU will be reset after flashing.') }}</span>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- End stm32flash options-->
                     <hr>
                 </div>
                 <!-- End advanced options-->
 
                 <!-- Pre-flash and post-flash settings -->
-                <div data-bind="visible: !showPostflashConfig() && (showAvrdudeConfig() || showBossacConfig() || showLpc1768Config() || showDfuConfig())">
+                <div data-bind="visible: !showPostflashConfig() && (showAvrdudeConfig() || showBossacConfig() || showLpc1768Config() || showDfuConfig() || showStm32flashConfig())">
                     <label data-bind="click: togglePostflashConfig" >
                         <i class="icon-chevron-right icon-fixed-width"></i>Pre-Flash and Post-Flash Settings
                     </label>


### PR DESCRIPTION
Board such as FYSETC Cheetah is using an STM32F1 MCU which hasn't DFU or USB flashing enabled. It embeds an ST serial bootloader instead. 

MCU BOOT0 pin is connected to a RTS pin, set to HIGH, to enter bootloader upon reset with DTR.
After flashing, normal reset doesn't start the firmware, and requires to set execution address instead.

Default settings with this implementation makes the plugin to work out of the box with FYSETC Cheetah board.
