### PR TITLE
Fix the path check for the LPC1768 firmware folder

### DIFF
--- a/octoprint_firmwareupdater/static/js/firmwareupdater.js
+++ b/octoprint_firmwareupdater/static/js/firmwareupdater.js
@@ -769,8 +769,7 @@ $(function() {
                 data: JSON.stringify({
                     command: "path",
                     path: self.configLpc1768Path(),
-                    check_type: "path",
-                    check_access: ["r", "w"],
+                    check_type: "dir",
                     check_writable_dir: "true"
                 }),
                 contentType: "application/json; charset=UTF-8",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_firmwareupdater"
 plugin_name = "OctoPrint-FirmwareUpdater"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.6.0"
+plugin_version = "1.6.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Previous check was allowing the path to be set to a file rather than forcing it to be a folder.