### PR TITLE
Add FIrmware Updater Tab

### DIFF
--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -317,13 +317,16 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 			"enable_postflash_commandline": None,
 			"enable_postflash_delay": None,
 			"enable_postflash_gcode": None,
-			"disable_bootloadercheck": None
+			"disable_bootloadercheck": None,
+			"enabledTab": True
 		}
 
 	#~~ Asset API
 
 	def get_assets(self):
-		return dict(js=["js/firmwareupdater.js"])
+		return dict(
+		js=["js/firmwareupdater.js"],
+		css=["css/firmwareupdater.css"])
 
 	#~~ Extra methods
 

--- a/octoprint_firmwareupdater/static/css/firmwareupdater.css
+++ b/octoprint_firmwareupdater/static/css/firmwareupdater.css
@@ -1,0 +1,6 @@
+ #tab_plugin_firmwareupdater iframe {
+  width: 100%;
+  height: 800px;
+  border: 1px solid #808080;
+}
+

--- a/octoprint_firmwareupdater/static/js/firmwareupdater.js
+++ b/octoprint_firmwareupdater/static/js/firmwareupdater.js
@@ -823,7 +823,9 @@ $(function() {
 
     OCTOPRINT_VIEWMODELS.push([
         FirmwareUpdaterViewModel,
+		
         ["settingsViewModel", "loginStateViewModel", "connectionViewModel", "printerStateViewModel"],
-        [document.getElementById("settings_plugin_firmwareupdater")]
+		
+        [document.getElementById("settings_plugin_firmwareupdater"), document.getElementById("settings_plugin_firmwareupdater_tab")]
     ]);
 });

--- a/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
+++ b/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
@@ -96,7 +96,7 @@
                     </div>
                 </div>
 				<div class="control-group">
-					<label class="control-label">{{ _('Enabled Tab?') }}</label>
+					<label class="control-label">{{ _('Enable Tab?') }}</label>
 					<div class="controls">
 						<label class="checkbox">
 							<input type="checkbox" data-bind="checked: enabled">

--- a/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
+++ b/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
@@ -95,6 +95,14 @@
                         </select>
                     </div>
                 </div>
+				<div class="control-group">
+					<label class="control-label">{{ _('Enabled Tab?') }}</label>
+					<div class="controls">
+						<label class="checkbox">
+							<input type="checkbox" data-bind="checked: enabled">
+						</label>
+					</div>
+				</div>
                 <hr>
 
                 <!-- avrdude options for 8-bit MCUs -->

--- a/octoprint_firmwareupdater/templates/firmwareupdater_tab.jinja2
+++ b/octoprint_firmwareupdater/templates/firmwareupdater_tab.jinja2
@@ -94,7 +94,7 @@
                     </div>
                 </div>
 				<div class="control-group">
-					<label class="control-label">{{ _('Enabled Tab?') }}</label>
+					<label class="control-label">{{ _('Enable Tab?') }}</label>
 					<div class="controls">
 						<label class="checkbox">
 							<input type="checkbox" data-bind="checked: enabled">

--- a/octoprint_firmwareupdater/templates/firmwareupdater_tab.jinja2
+++ b/octoprint_firmwareupdater/templates/firmwareupdater_tab.jinja2
@@ -1,0 +1,517 @@
+<div id="settings_plugin_firmwareupdater_tab">
+
+    <div class="pull-right">
+        <button class="btn btn-small" data-bind="click: showPluginConfig" title="{{ _('Plugin Configuration') }}"><i class="icon-wrench"></i></button>
+    </div>
+
+    <h3>{{ _('Firmware Updater') }}</h3>
+
+    <form class="form-fluid">
+
+        <div class="control-group" title="{{ _('Select the serial port where your printer is connected') }}">
+            <label class="control-label">{{ _('Serial Port') }}</label>
+            <div class="controls">
+                <select data-bind="options: connection.portOptions, value: flashPort"></select>
+            </div>
+        </div>
+
+        <div class="control-group">
+            <label class="control-label">{{ _('... from file') }}</label>
+            <div class="controls controls-row">
+                <div class="span4">
+                    <div class="input-group controls-row">
+                        <span class="btn input-group-btn fileinput-button pull-left">
+                          <span>{{ _('Browse...') }}</span>
+                          <input id="settings_firmwareupdater_selectFilePath" type="file" name="file" data-bind='attr: { accept: ".hex,.bin" }' data-url="{{ url_for("plugin.firmwareupdater.flash_firmware") }}">
+                        </span>
+                    </div>
+                </div>
+				<span class="span4">
+                    <input class="input input-block-level" type="text" data-bind="value: firmwareFileName" disabled>
+                </span>
+                <div class="span4">
+                    <button class="btn btn-primary btn-block" data-bind="attr: {title: fileFlashButtonText}, click: startFlashFromFile, enable: firmwareFileName, css: {disabled: !firmwareFileName() || isBusy()}">{{ _('Flash from File') }}</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="control-group">
+            <label class="control-label">{{ _('... from URL') }}</label>
+            <div class="controls controls-row">
+                <div class="span4">
+                    <input class="input-block-level" type="text" data-bind='value: firmwareFileURL, valueUpdate: "afterkeydown"'>
+                </div>
+                <div class="span4">
+                    <button class="btn btn-primary btn-block" data-bind='attr: {title: urlFlashButtonText}, click: startFlashFromURL, enable: firmwareFileURL, css: {disabled: !firmwareFileURL() || isBusy()}'>{{ _('Flash from URL') }}</button>
+                </div>
+            </div>
+        </div>
+
+        <hr>
+        <div class="progress progress-info progress-striped active" data-bind="visible: isBusy()">
+            <div class="bar" style="width: 100%;"><label data-bind="text: progressBarText()"></label></div>
+            <hr>
+        </div>
+        <div class="alert" style="text-align: center;" data-bind="text: alertMessage, visible: showAlert(), css: alertType"></div>
+        <div>
+            <i class="icon-list"></i>&nbsp;&nbsp;<h5 style="display: inline-block">Instructions</h5>
+            <ol>
+                <li>Click the wrench icon in the top right corner and configure the settings for the plugin</li>
+                <li>Either click the 'Browse' button to upload a file, or provide a URL to a file</li>
+                <li>Click the appropriate 'Flash from' button</li>
+                <li>Wait for the flash to complete</li>
+            </ol>
+            <i class="icon-warning-sign"></i>&nbsp;&nbsp;<h5 style="display: inline-block">Warning</h5>
+            <p>As with any firmware flashing there is a risk that things may go wrong.</p>
+            <ul>
+                <li><b>Do not</b> power-cycle or restart your printer while flashing is in progress</li>
+                <li><b>Do not</b> attempt to flash a firmware file which includes a bootloader</li>
+            </ul>
+            <p>No warranty is given, and no responsibility can be accepted if there are problems.  By using this plugin you accept the associated risks.</p>
+            <i class="icon-book"></i>&nbsp;&nbsp;<h5 style="display: inline-block">Documentation</h5>
+            <p>Documentation is available on <a target=_new href="https://github.com/OctoPrint/OctoPrint-FirmwareUpdater/blob/master/README.md">Github</p>
+         </div>
+    </form>
+
+    <div id="settings_plugin_firmwareupdater_configurationdialog" class="modal hide fade">
+        <div class="modal-header">
+            <a href="#" class="close" data-dismiss="modal" aria-hidden="true">&times;</a>
+            <h3>{{ _('Plugin Configuration') }}</h3>
+        </div>
+        <div class="modal-body">
+            <form class="form-horizontal">
+                <div class="control-group">
+                    <label class="control-label">{{ _('Flash method') }}</label>
+                    <div class="controls">
+	                    <select data-bind="value: configFlashMethod">
+                            <option></option>
+                            <option value=avrdude>avrdude (Atmel AVR Family)</option>
+                            <option value=bossac>bossac (Atmel SAM Family)</option>
+                            <option value=dfuprogrammer>dfu-programmer (Atmel AVR with DFU)</option>
+                            <option value=lpc1768>lpc1768 (LPC1768-based Boards)</option>
+                            <option value=stm32flash>stm32flash (STM32 built-in bootloader)</option>
+                        </select>
+                    </div>
+                </div>
+                <hr>
+
+                <!-- avrdude options for 8-bit MCUs -->
+                <div data-bind="visible: showAvrdudeConfig">
+                    <div class="control-group">
+                        <label class="control-label">{{ _('AVR MCU') }}</label>
+                        <div class="controls">
+                            <select data-bind="value: configAvrdudeMcu">
+                                <option value=></option>
+                                <option value=m644p>ATmega644p</option>
+                                <option value=m1280>ATmega1280</option>
+                                <option value=m1284p>ATmega1284p</option>
+                                <option value=m2560>ATmega2560</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="control-group" data-bind="css: {error: avrdudePathBroken, success: avrdudePathOk}">
+                        <label class="control-label">{{ _('Path to avrdude') }}</label>
+                        <div class="controls">
+                            <div class="input-append">
+                                <input type="text" class="input-block-level" data-bind='value: configAvrdudePath, valueUpdate: "afterkeydown"'>
+                                <button class="btn" type="button" data-bind="click: testAvrdudePath, enable: configAvrdudePath, css: {disabled: !configAvrdudePath()}">{{ _('Test') }}</button>
+                            </div>
+                            <span class="help-block" data-bind="visible: avrdudePathBroken() || avrdudePathOk, text: avrdudePathText"></span>
+                        </div>
+                    </div>
+                    <div class="control-group">
+                        <label class="control-label">{{ _('AVR Programmer Type') }}</label>
+                        <div class="controls">
+                            <select data-bind="value: configAvrdudeProgrammer">
+                                <option value=></option>
+                                <option value=arduino>arduino</option>
+                                <option value=usbasp>usbasp</option>
+                                <option value=stk500v2>stk500v2</option>
+                                <option value=wiring>wiring</option>
+                                <option value=linuxgpio>linuxgpio</option>
+                            </select>
+                        </div>
+                    </div>
+                    <hr>
+                </div>
+                <!-- end avrdude options -->
+
+                <!-- bossac options for 32-bit MCUs -->
+                <div data-bind="visible: showBossacConfig">
+                    <div class="control-group" data-bind="css: {error: bossacPathBroken, success: bossacPathOk}">
+                        <label class="control-label">{{ _('Path to bossac') }}</label>
+                        <div class="controls">
+                            <div class="input-append">
+                                <input type="text" class="input-block-level" data-bind='value: configBossacPath, valueUpdate: "afterkeydown"'>
+                                <button class="btn" type="button" data-bind="click: testBossacPath, enable: configBossacPath, css: {disabled: !configBossacPath()}">{{ _('Test') }}</button>
+                            </div>
+                            <span class="help-block" data-bind="visible: bossacPathBroken() || bossacPathOk, text: bossacPathText"></span>
+                        </div>
+                    </div>
+                    <hr>
+                </div>
+                <!-- end bossac options -->
+
+                <!-- lpc1768 options for LPC1768 MCUs -->
+                <div data-bind="visible: showLpc1768Config">
+                    <div class="control-group" data-bind="css: {error: lpc1768PathBroken, success: lpc1768PathOk}">
+                        <label class="control-label">{{ _('Path to firmware folder') }}</label>
+                        <div class="controls">
+                            <div class="input-append">
+                                <input type="text" class="input-block-level" data-bind='value: configLpc1768Path, valueUpdate: "afterkeydown"'>
+                                <button class="btn" type="button" data-bind="click: testLpc1768Path, enable: configLpc1768Path, css: {disabled: !configLpc1768Path()}">{{ _('Test') }}</button>
+                            </div>
+                            <span class="help-block" data-bind="visible: lpc1768PathBroken() || lpc1768PathOk, text: lpc1768PathText"></span>
+                        </div>
+                    </div>
+                    <hr>
+                </div>
+                <!-- end lpc1768 options -->
+
+                <!-- dfu-programmer options -->
+                <div data-bind="visible: showDfuConfig">
+                    <div class="control-group">
+                        <label class="control-label">{{ _('AVR MCU') }}</label>
+                        <div class="controls">
+                            <select data-bind="value: configDfuMcu">
+                                <option value=></option>
+                                <option value=at90usb1286>AT90USB1286</option>
+                                <option value=at90usb1287>AT90USB1287</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="control-group" data-bind="css: {error: dfuPathBroken, success: dfuPathOk}">
+                        <label class="control-label">{{ _('Path to dfu-programmer') }}</label>
+                        <div class="controls">
+                            <div class="input-append">
+                                <input type="text" class="input-block-level" data-bind='value: configDfuPath, valueUpdate: "afterkeydown"'>
+                                <button class="btn" type="button" data-bind="click: testDfuPath, enable: configDfuPath, css: {disabled: !configDfuPath()}">{{ _('Test') }}</button>
+                            </div>
+                            <span class="help-block" data-bind="visible: dfuPathBroken() || dfuPathOk, text: dfuPathText"></span>
+                        </div>
+                    </div>
+                    <hr>
+                </div>
+                <!-- end avrdude options -->
+
+                <!-- stm32flash options for STM32 MCUs -->
+                <div data-bind="visible: showStm32flashConfig">
+                    <div class="control-group" data-bind="css: {error: stm32flashPathBroken, success: stm32flashPathOk}">
+                        <label class="control-label">{{ _('Path to stm32flash') }}</label>
+                        <div class="controls">
+                            <div class="input-append">
+                                <input type="text" class="input-block-level" data-bind='value: configStm32flashPath, valueUpdate: "afterkeydown"'>
+                                <button class="btn" type="button" data-bind="click: testStm32flashPath, enable: configStm32flashPath, css: {disabled: !configStm32flashPath()}">{{ _('Test') }}</button>
+                            </div>
+                            <span class="help-block" data-bind="visible: stm32flashPathBroken() || stm32flashPathOk, text: stm32flashPathText"></span>
+                        </div>
+                    </div>
+                    <hr>
+                </div>
+                <!-- end stm32flash options -->
+
+                <!-- advanced options -->
+
+                <div data-bind="visible: !showAdvancedConfig() && (showAvrdudeConfig() || showBossacConfig() || showLpc1768Config() || showDfuConfig() || showStm32flashConfig())">
+                    <label data-bind="click: toggleAdvancedConfig" >
+                        <i class="icon-chevron-right icon-fixed-width"></i>Advanced Settings
+                    </label>
+                </div>
+                <div data-bind="visible: showAdvancedConfig">
+                    <label data-bind="click: toggleAdvancedConfig" >
+                            <i class="icon-chevron-down icon-fixed-width"></i>Advanced Settings
+                    </label>
+
+                    <!-- Advanced avrdude options-->
+                    <div data-bind="visible: showAvrdudeConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('avrdude Baud Rate') }}</label>
+                            <div class="controls">
+                                <select data-bind="value: configAvrdudeBaudRate">
+                                    <option value=>Default</option>
+                                    <option value=19200>19200</option>
+                                    <option value=38400>38400</option>
+                                    <option value=57600>57600</option>
+                                    <option value=115200>115200</option>
+                                    <option value=250000>250000</option>
+                                </select>
+                                <span class="help-block">{{ _('Override the default avrdude baud rate.') }}</span>
+                            </div>
+                        </div>
+                        <div class="control-group" data-bind="css: {error: avrdudeConfPathBroken, success: avrdudeConfPathOk}">
+                            <label class="control-label">{{ _('Path to avrdude config file') }}</label>
+                            <div class="controls">
+                                <div class="input-append">
+                                    <input type="text" class="input-block-level" data-bind='value: configAvrdudeConfigFile, valueUpdate: "afterkeydown"'>
+                                    <button class="btn" type="button" data-bind="click: testAvrdudeConf, enable: configAvrdudeConfigFile, css: {disabled: !configAvrdudeConfigFile()}">{{ _('Test') }}</button>
+                                </div>
+                                <span class="help-block" data-bind="visible: avrdudeConfPathBroken() || avrdudeConfPathOk, text: avrdudeConfPathText"></span>
+                                <span class="help-block">{{ _('Can be left empty, in which case avrdude will use the global configuration file.') }}</span>
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Disable write verification') }}</label>
+                            <div class="controls">
+                                <div class="input">
+                                    <input type="checkbox" class="input-block-level" data-bind="checked: configAvrdudeDisableVerification">
+                                </div>
+                                <span class="help-block">{{ _('If checked the avrdude verification phase will be skipped.') }}</span>
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Command line') }}</label>
+                            <div class="controls">
+                                <div class="input-append">
+                                    <input type="text" class="input-block-level" data-bind="value: configAvrdudeCommandLine">
+                                    <button class="btn" type="button" data-bind="click: resetAvrdudeCommandLine">{{ _('Reset') }}</button>
+                                </div>
+                                <span class="help-block">{{ _('Customize the avrdude command line.') }}</span>
+                            </div>
+                        </div>
+                        <div class="control-group">
+                        <label class="control-label">{{ _('Disable bootloader warning') }}</label>
+                        <div class="controls">
+                            <div class="input">
+                                <input type="checkbox" class="input-block-level" data-bind="checked: configDisableBootloaderCheck">
+                            </div>
+                            <span class="help-block">{{ _('If checked the bootloader warning will be suppressed.') }}</span>
+                        </div>
+                    </div>
+                    </div>
+                    <!-- End advanced avrdude options -->
+
+                    <!-- Advanced bossac options -->
+                    <div data-bind="visible: showBossacConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Disable write verification') }}</label>
+                            <div class="controls">
+                                <div class="input">
+                                    <input type="checkbox" class="input-block-level" data-bind="checked: configBossacDisableVerification">
+                                </div>
+                                <span class="help-block">{{ _('If checked the bossac verification phase will be skipped.') }}</span>
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Command line') }}</label>
+                            <div class="controls">
+                                <div class="input-append">
+                                    <input type="text" class="input-block-level" data-bind="value: configBossacCommandLine">
+                                    <button class="btn" type="button" data-bind="click: resetBossacCommandLine">{{ _('Reset') }}</button>
+                                </div>
+                                <span class="help-block">{{ _('Customize the bossac command line.') }}</span>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- End advanced bossac options-->
+
+                    <!-- Advanced lpc1768 options -->
+                    <div data-bind="visible: showLpc1768Config">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Reset before flashing') }}</label>
+                            <div class="controls">
+                                <div class="input">
+                                    <input type="checkbox" data-bind="checked: configLpc1768ResetBeforeFlash">
+                                </div>
+                                <span class="help-block">{{ _('If checked the board will be reset before a firmware update is attempted. Helps to ensure that the SD card is properly mounted.') }}</span>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Advanced lpc1768 options -->
+
+                     <!-- Advanced dfu-programmer options -->
+                    <div data-bind="visible: showDfuConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Erase command line') }}</label>
+                            <div class="controls">
+                                <div class="input-append">
+                                    <input type="text" class="input-block-level" data-bind="value: configDfuEraseCommandLine">
+                                    <button class="btn" type="button" data-bind="click: resetDfuEraseCommandLine">{{ _('Reset') }}</button>
+                                </div>
+                                <span class="help-block">{{ _('Customize the dfu-programmer erase command line.') }}</span>
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Flash command line') }}</label>
+                            <div class="controls">
+                                <div class="input-append">
+                                    <input type="text" class="input-block-level" data-bind="value: configDfuCommandLine">
+                                    <button class="btn" type="button" data-bind="click: resetDfuCommandLine">{{ _('Reset') }}</button>
+                                </div>
+                                <span class="help-block">{{ _('Customize the dfu-programmer flash command line.') }}</span>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- End advanced bossac options-->
+
+                    <!-- Advanced stm32flash options -->
+                    <div data-bind="visible: showStm32flashConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Verify while writing') }}</label>
+                            <div class="controls">
+                                <div class="input">
+                                    <input type="checkbox" data-bind="checked: configStm32flashVerify">
+                                </div>
+                                <span class="help-block">{{ _('If checked memory will be verified as it get flashed. Otherwise memory won\'t be verified.') }}</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div data-bind="visible: showStm32flashConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('BOOT0 pin') }}</label>
+                            <div class="controls">
+                                <select data-bind="value: configStm32flashBoot0Pin">
+                                    <option value="dtr">DTR</option>
+                                    <option value="rts">RTS</option>
+                                </select>
+                                <label class="checkbox">
+                                    <input type="checkbox" data-bind="checked: configStm32flashBoot0Low"> Low
+                                </label>
+                                <span class="help-block">{{ _('Serial pin to enable bootloader') }}</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div data-bind="visible: showStm32flashConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Reset pin') }}</label>
+                            <div class="controls">
+                                <select data-bind="value: configStm32flashResetPin">
+                                    <option value="dtr">DTR</option>
+                                    <option value="rts">RTS</option>
+                                </select>
+                                <label class="checkbox">
+                                    <input type="checkbox" data-bind="checked: configStm32flashResetLow"> Low
+                                </label>
+                                <span class="help-block">{{ _('Serial pin to reset MCU') }}</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div data-bind="visible: showStm32flashConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Start execution') }}</label>
+                            <div class="controls">
+                                <label class="checkbox">
+                                    <input type="checkbox" data-bind="checked: configStm32flashExecute"> Enabled
+                                </label>
+                                <div class="input">
+                                    <input type="text" class="input-block-level" data-bind="value: configStm32flashExecuteAddress, enable: configStm32flashExecute, css: {disabled: !configStm32flashExecute()}">
+                                </div>
+                                <span class="help-block">{{ _('Address to execute after flashing.') }}</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div data-bind="visible: showStm32flashConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Reset after flashing') }}</label>
+                            <div class="controls">
+                                <div class="input">
+                                    <input type="checkbox" data-bind="checked: configStm32flashReset, disable: configStm32flashExecute">
+                                </div>
+                                <span class="help-block">{{ _('If checked MCU will be reset after flashing.') }}</span>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- End stm32flash options-->
+                    <hr>
+                </div>
+                <!-- End advanced options-->
+
+                <!-- Pre-flash and post-flash settings -->
+                <div data-bind="visible: !showPostflashConfig() && (showAvrdudeConfig() || showBossacConfig() || showLpc1768Config() || showDfuConfig() || showStm32flashConfig())">
+                    <label data-bind="click: togglePostflashConfig" >
+                        <i class="icon-chevron-right icon-fixed-width"></i>Pre-Flash and Post-Flash Settings
+                    </label>
+                </div>
+                <div data-bind="visible: showPostflashConfig">
+                    <label data-bind="click: togglePostflashConfig" >
+                            <i class="icon-chevron-down icon-fixed-width"></i>Pre-Flash and Post-Flash Settings
+                    </label>
+                    <!-- Pre-flash commandline -->
+                    <div class="control-group">
+                        <label class="control-label">{{ _('Pre-flash command') }}</label>
+                        <div class="controls">
+                            <label class="checkbox">
+                                <input type="checkbox" data-bind="checked: configEnablePreflashCommandline"> Enabled
+                            </label>
+                            <div class="input">
+                                <input type="text" class="input-block-level" data-bind="value: configPreflashCommandline, enable: configEnablePreflashCommandline">
+                            </div>
+                            <span class="help-block">{{ _('System command line to execute before flashing.') }}</span>
+                        </div>
+                    </div>
+                    <!-- End pre-flash commandline -->
+                    
+                    <!-- Post-flash commandline -->
+                    <div class="control-group">
+                        <label class="control-label">{{ _('Post-flash command') }}</label>
+                        <div class="controls">
+                            <label class="checkbox">
+                                <input type="checkbox" data-bind="checked: configEnablePostflashCommandline"> Enabled
+                            </label>
+                            <div class="input">
+                                <input type="text" class="input-block-level" data-bind="value: configPostflashCommandline, enable: configEnablePostflashCommandline">
+                            </div>
+                            <span class="help-block">{{ _('System command line to execute after flashing.') }}</span>
+                        </div>
+                    </div>
+                    <!-- End post-flash commandline -->
+
+                    <!-- Post-flash delay -->
+                    <div class="control-group">
+                        <label class="control-label">{{ _('Post-flash delay') }}</label>
+                        <div class="controls">
+                            <label class="checkbox">
+                                <input type="checkbox" data-bind="checked: configEnablePostflashDelay"> Enabled
+                            </label>
+                            <div class="input-append">
+                                <input type="number" class="input-mini text-right" step=any min="0" max="180" data-bind="value: configPostflashDelay, enable: configEnablePostflashDelay">
+                                <span class="add-on">seconds</span>
+                            </div>
+                            <span class="help-block">{{ _('Give the board time to boot before allowing OctoPrint to reconnect.') }}</span>
+                        </div>
+                    </div>
+                    <!-- End post-flash delay -->
+
+                    <!-- Post-flash gcode -->
+                    <div class="control-group">
+                        <label class="control-label">{{ _('Post-flash gcode') }}</label>
+                        <div class="controls">
+                            <label class="checkbox">
+                                <input type="checkbox" data-bind="checked: configEnablePostflashGcode"> Enabled
+                            </label>
+                            <div class="input">
+                                <input type="text" class="input-block-level" data-bind="value: configPostflashGcode, enable: configEnablePostflashGcode">
+                            </div>
+                            <span class="help-block">{{ _('Gcode commands which will be run when the printer reconnects after firmware is flashed. Separate multiple commands with a semi colon.') }}</span>
+                        </div>
+                    </div>
+                    <!-- End post-flash gcode -->
+                </div>
+                <!-- End pre-flash and post-flash settings -->
+            </form>
+        </div>
+        <div class="modal-footer">
+            <button class="btn" data-dismiss="modal" data-bind="click: onConfigHidden" aria-hidden="true">{{ _('Cancel') }}</button>
+            <button class="btn btn-primary" data-bind="click: onConfigClose" aria-hidden="true">{{ _('Save') }}</button>
+        </div>
+    </div>
+    <div id="BootLoaderWarning" class="modal hide fade">
+        <div class="modal-header">
+            <a href="#" class="close" data-dismiss="modal" aria-hidden="true">&times;</a>
+            <h3>Firmware Updater</h3>
+        </div>
+        <div class="modal-body">
+            <i class="icon-warning-sign"></i>&nbsp;&nbsp;<h5 style="display: inline-block">Warning</h5>
+            <p>
+                {{ _("You have selected a file with 'bootloader' in the name. Flashing a firmware file which includes a bootloader may corrupt the board's bootloader.") }}
+            </p>
+        </div>
+        <div class="modal-footer">
+            <a href="#" class="btn" data-dismiss="modal" aria-hidden="true" data-bind="click: returnFalse">{{ _('OK') }}</a>
+        </div>
+    </div>
+</div>
+

--- a/octoprint_firmwareupdater/templates/firmwareupdater_tab.jinja2
+++ b/octoprint_firmwareupdater/templates/firmwareupdater_tab.jinja2
@@ -1,4 +1,4 @@
-<div id="settings_plugin_firmwareupdater_tab">
+<div id="settings_plugin_firmwareupdater_tab" data-bind="visible: enabled()">
 
     <div class="pull-right">
         <button class="btn btn-small" data-bind="click: showPluginConfig" title="{{ _('Plugin Configuration') }}"><i class="icon-wrench"></i></button>
@@ -93,6 +93,14 @@
                         </select>
                     </div>
                 </div>
+				<div class="control-group">
+					<label class="control-label">{{ _('Enabled Tab?') }}</label>
+					<div class="controls">
+						<label class="checkbox">
+							<input type="checkbox" data-bind="checked: enabled">
+						</label>
+					</div>
+				</div>
                 <hr>
 
                 <!-- avrdude options for 8-bit MCUs -->


### PR DESCRIPTION
Adds the Firmware Updater as a tab in the main Octoprint screen.

Useful for quick access for people that are updating their firmware a lot.


Solves this issue: [[Feature Request] Add a quick button to open dialog from top bar. #118](https://github.com/OctoPrint/OctoPrint-FirmwareUpdater/issues/118)
So instead of a button on the nav its a tab.

![firmwareupdater_tabpic](https://user-images.githubusercontent.com/663343/76859270-340c1e00-6816-11ea-8c60-375ce994f03d.png)
