### PR TITLE
Sync write buffer to SD card (LPC1768)

### DIFF
--- a/octoprint_firmwareupdater/methods/lpc1768.py
+++ b/octoprint_firmwareupdater/methods/lpc1768.py
@@ -81,6 +81,17 @@ def _flash_lpc1768(self, firmware=None, printer_port=None):
         self._send_status("flasherror")
         return False
 
+    # On some systems there is a problem: if we unmount the SD card immediately, the file may not end up actually copied.
+    # The code block below helps.
+    self._logger.info(u"Synchronizing cached writes to SD card")
+    try:
+        r = os.system('sync')
+    except:
+        e = sys.exc_info()[0]
+        self._logger.error("Error executing 'sync' command")
+        return False
+    time.sleep(1)
+
     unmount_command = 'sudo umount ' + lpc1768_path
     self._logger.info(u"Unmounting SD card: '{}'".format(unmount_command))
     try:


### PR DESCRIPTION
On some systems there is a problem: if we unmount the SD card
immediately, the firmware file may not end up actually copied.

This may be related to OctoPrint/OctoPrint-FirmwareUpdater#101

The plugin tells that the flashing was successful. But still the
printer stays with the old firmware. Which is easily checked by M115,
for example.

This should not be happening because 'shutil.copyfile()'
python command and 'umount' system command are considered to be safe
and synchronous. But it still happens.

The problem stops occurring if we sleep for one second before
unmounting the SD card. Or run 'sync'. At least on my system.

This patch uses both methods.

It would be nice if we could also add a hash check for FIRMWARE.CUR
after reset, so we would be able to really tell if firmware upload was
successful or not.