### PR TITLE
Add Binary File Transfer support

### DIFF
--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -22,6 +22,7 @@ from octoprint_firmwareupdater.methods import bossac
 from octoprint_firmwareupdater.methods import dfuprog
 from octoprint_firmwareupdater.methods import lpc1768
 from octoprint_firmwareupdater.methods import stm32flash
+from octoprint_firmwareupdater.methods import marlinbft
 
 class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
                             octoprint.plugin.TemplatePlugin,
@@ -40,8 +41,22 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 	def initialize(self):
 		# TODO: make method configurable via new plugin hook "octoprint.plugin.firmwareupdater.flash_methods",
 		# also include prechecks
-		self._flash_prechecks = dict(avrdude=avrdude._check_avrdude, bossac=bossac._check_bossac, dfuprogrammer=dfuprog._check_dfuprog, lpc1768=lpc1768._check_lpc1768, stm32flash=stm32flash._check_stm32flash)
-		self._flash_methods = dict(avrdude=avrdude._flash_avrdude, bossac=bossac._flash_bossac, dfuprogrammer=dfuprog._flash_dfuprog, lpc1768=lpc1768._flash_lpc1768, stm32flash=stm32flash._flash_stm32flash)
+		self._flash_prechecks = dict(
+			avrdude=avrdude._check_avrdude,
+			bossac=bossac._check_bossac,
+			dfuprogrammer=dfuprog._check_dfuprog,
+			lpc1768=lpc1768._check_lpc1768,
+			stm32flash=stm32flash._check_stm32flash,
+			marlinbft=marlinbft._check_marlinbft
+		)
+		self._flash_methods = dict(
+			avrdude=avrdude._flash_avrdude,
+			bossac=bossac._flash_bossac,
+			dfuprogrammer=dfuprog._flash_dfuprog,
+			lpc1768=lpc1768._flash_lpc1768,
+			stm32flash=stm32flash._flash_stm32flash,
+			marlinbft=marlinbft._flash_marlinbft
+		)
 
 		console_logging_handler = logging.handlers.RotatingFileHandler(self._settings.get_plugin_logfile_path(postfix="console"), maxBytes=2*1024*1024)
 		console_logging_handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))

--- a/octoprint_firmwareupdater/methods/avrdude.py
+++ b/octoprint_firmwareupdater/methods/avrdude.py
@@ -67,7 +67,7 @@ def _check_avrdude(self):
     else:
         return True
 
-def _flash_avrdude(self, firmware=None, printer_port=None):
+def _flash_avrdude(self, firmware=None, printer_port=None, **kwargs):
     assert(firmware is not None)
     assert(printer_port is not None)
 

--- a/octoprint_firmwareupdater/methods/bossac.py
+++ b/octoprint_firmwareupdater/methods/bossac.py
@@ -33,7 +33,7 @@ def _check_bossac(self):
     else:
         return True
 
-def _flash_bossac(self, firmware=None, printer_port=None):
+def _flash_bossac(self, firmware=None, printer_port=None, **kwargs):
     assert(firmware is not None)
     assert(printer_port is not None)
 

--- a/octoprint_firmwareupdater/methods/dfuprog.py
+++ b/octoprint_firmwareupdater/methods/dfuprog.py
@@ -30,7 +30,7 @@ def _check_dfuprog(self):
     else:
         return True
 
-def _flash_dfuprog(self, firmware=None, printer_port=None):
+def _flash_dfuprog(self, firmware=None, printer_port=None, **kwargs):
     assert(firmware is not None)
 
     if not _erase_dfuprog(self):

--- a/octoprint_firmwareupdater/methods/lpc1768.py
+++ b/octoprint_firmwareupdater/methods/lpc1768.py
@@ -24,7 +24,7 @@ def _check_lpc1768(self):
     else:
         return True
 
-def _flash_lpc1768(self, firmware=None, printer_port=None):
+def _flash_lpc1768(self, firmware=None, printer_port=None, **kwargs):
     assert(firmware is not None)
     assert(printer_port is not None)
 

--- a/octoprint_firmwareupdater/methods/marlinbft.py
+++ b/octoprint_firmwareupdater/methods/marlinbft.py
@@ -1,66 +1,113 @@
-import re
 import os
 import time
 import shutil
 import subprocess
 import sys
-import copy
 import binproto2 as mbp
 
-def _check_marlinbft(self):
-    # TODO: Figure out how to check for the Marlin BFT capability
-    return True
+current_baudrate = None
 
-def _flash_marlinbft(self, firmware=None, printer_port=None):
+def _check_marlinbft(self):
+    self._logger.info("Marlin BINARY_FILE_TRANSFER capability is %s" % (self._settings.get_boolean(["marlinbft_hascapability"])))
+    if not self._settings.get_boolean(["marlinbft_hascapability"]):
+        self._logger.error("Marlin BINARY_FILE_TRANSFER capability is not supported")
+        self._send_status("flasherror", subtype="nobftcap")
+        return False
+    elif not self._printer.is_operational():
+        self._logger.error("Printer is not connected")
+        self._send_status("flasherror", subtype="notconnected")
+        return False
+    else:
+        global current_baudrate
+        _, current_port, current_baudrate, current_profile = self._printer.get_current_connection()
+        return True
+
+def _flash_marlinbft(self, firmware=None, printer_port=None, **kwargs):
     assert(firmware is not None)
     assert(printer_port is not None)
+    assert(current_baudrate is not None)
 
-    self._logger.info(u"Transfering file to printer using Marlin BFT '{}' -> /firmware.bin".format(firmware))
-    self._send_status("progress", subtype="sending")
+    # Get the settings
+    bft_waitafterconnect = self._settings.get_int(["marlinbft_waitafterconnect"])
+    bft_timeout = self._settings.get_int(["marlinbft_timeout"])
+    bft_verbose = self._settings.get_boolean(["marlinbft_progresslogging"])
+
+    # Loggging
+    if bft_verbose:
+        transfer_logger = self._logger
+    else:
+        transfer_logger = None
 
     try:
         # Open the binary protocol connection
-        protocol = mbp.Protocol(printer_port, 115200, 512, 1000, self._logger)
+        self._logger.info("Current Baud: %s" % current_baudrate)
+
+        self._logger.info(u"Initializing Marlin BFT protocol")
+        self._send_status("progress", subtype="bftinit")
+        protocol = mbp.Protocol(printer_port, current_baudrate, 512, bft_timeout, self._logger)
+        
+        # Wait after connect protocol
+        if bft_waitafterconnect > 0:
+            self._logger.info("waiting %ss after protocol connect" % bft_waitafterconnect)
+            time.sleep(bft_waitafterconnect)
 
         # Make sure temperature auto-reporting is disabled
         protocol.send_ascii("M155 S0")
 
         # Connect
+        self._logger.info(u"Connecting to printer at '{}' using Marlin BFT protocol".format(printer_port))
+        self._send_status("progress", subtype="bftconnect")
         protocol.connect()
-
+      
         # Copy the file
-        filetransfer = mbp.FileTransferProtocol(protocol, None)
+        self._logger.info(u"Transfering file to printer using Marlin BFT '{}' -> /firmware.bin".format(firmware))
+        self._send_status("progress", subtype="sending")
+        filetransfer = mbp.FileTransferProtocol(protocol, logger=transfer_logger)
         filetransfer.copy(firmware, 'firmware.bin', True, False)
-
-        self._logger.info(u"Transfer complete")
+        self._logger.info(u"Binary file transfer complete")
 
         # Disconnect
         protocol.disconnect()
+
+        # Display a message on the LCD
+        protocol.send_ascii("M117 Resetting...")
+
+    except mbp.exceptions.ConnectionLost:
+        self._logger.exception(u"Flashing failed. Unable to connect to printer.")
+        self._send_status("flasherror", message="Unable to open binary file transfer connection")
+        return False
+    
+    except mbp.exceptions.FatalError:
+        self._logger.exception(u"Flashing failed. Too many retries.")
+        self._send_status("flasherror", message="Unable to transfer firmware file to printer - too many retries")
+        return False
 
     except:
         self._logger.exception(u"Flashing failed. Unable to transfer file.")
         self._send_status("flasherror", message="Unable to transfer firmware file to printer")
         return False
-
+    
     finally:
         if (protocol):
             protocol.shutdown()
 
     self._send_status("progress", subtype="boardreset")
     self._logger.info(u"Firmware update reset: attempting to reset the board")
-    if not _reset_board(self, printer_port):
+    if not _reset_board(self, printer_port, current_baudrate):
         self._logger.error(u"Reset failed")
         return False
 
     return True
 
-def _reset_board(self, printer_port=None):
+def _reset_board(self, printer_port=None, current_baudrate=None):
     assert(printer_port is not None)
+    assert(current_baudrate is not None)
+
     self._logger.info(u"Resetting printer at '{port}'".format(port=printer_port))
 
     # Configure the port
     try:
-        os.system('stty -F ' + printer_port + ' speed 115200 -echo > /dev/null')
+        os.system('stty -F ' + printer_port + ' speed ' + str(current_baudrate) + ' -echo > /dev/null')
     except:
         self._logger.exception(u"Error configuring serial port.")
         self._send_status("flasherror", message="Board reset failed")

--- a/octoprint_firmwareupdater/methods/marlinbft.py
+++ b/octoprint_firmwareupdater/methods/marlinbft.py
@@ -1,0 +1,255 @@
+import re
+import os
+import time
+import shutil
+import subprocess
+import sys
+
+def _check_marlinbft(self):
+    lpc1768_path = self._settings.get(["lpc1768_path"])
+    pattern = re.compile("^(\/[^\0/]+)+$")
+
+    if not pattern.match(lpc1768_path):
+        self._logger.error(u"Firmware folder path is not valid: {path}".format(path=lpc1768_path))
+        return False
+    elif lpc1768_path is None:
+        self._logger.error(u"Firmware folder path is not set.")
+        return False
+    if not os.path.exists(lpc1768_path):
+        self._logger.error(u"Firmware folder path does not exist: {path}".format(path=lpc1768_path))
+        return False
+    elif not os.path.isdir(lpc1768_path):
+        self._logger.error(u"Firmware folder path is not a folder: {path}".format(path=lpc1768_path))
+        return False
+    else:
+        return True
+
+def _flash_marlinbft(self, firmware=None, printer_port=None):
+    assert(firmware is not None)
+    assert(printer_port is not None)
+
+    lpc1768_path = self._settings.get(["lpc1768_path"])
+    working_dir = os.path.dirname(lpc1768_path)
+
+    if self._settings.get_boolean(["lpc1768_preflashreset"]):
+        self._send_status("progress", subtype="boardreset")
+
+        # Sync the filesystem to flush writes
+        self._logger.info(u"Synchronizing cached writes to SD card")
+        try:
+            r = os.system('sync')
+        except:
+            e = sys.exc_info()[0]
+            self._logger.error("Error executing 'sync' command")
+            return False
+        time.sleep(1)
+
+        if os.access(lpc1768_path, os.W_OK):
+            unmount_command = self._settings.get(["lpc1768_unmount_command"])
+            if unmount_command:
+                unmount_command = unmount_command.replace("{mountpoint}", lpc1768_path)
+
+                self._logger.info(u"Unmounting SD card: '{}'".format(unmount_command))
+                try:
+                    p = subprocess.Popen(unmount_command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+                    out, err = p.communicate()
+                    r = p.returncode
+
+                except:
+                    e = sys.exc_info()[0]
+                    self._logger.error("Error executing unmount command '{}'".format(unmount_command))
+                    self._logger.error("{}".format(str(e)))
+                    self._send_status("flasherror", message="Unable to unmount SD card")
+                    return False
+
+                if r != 0:
+                    if err.strip().endswith("not mounted."):
+                        self._logger.info("{}".format(err.strip()))
+                    else:
+                        self._logger.error("Error executing unmount command '{}'".format(unmount_command))
+                        self._logger.error("{}".format(err.strip()))
+                        self._send_status("flasherror", message="Unable to unmount SD card")
+                        return False
+        else:
+            self._logger.info(u"SD card not mounted, skipping unmount")
+
+        self._logger.info(u"Pre-flash reset: attempting to reset the board")
+        if not _reset_lpc1768(self, printer_port):
+            self._logger.error(u"Reset failed")
+            return False
+
+    # Release the SD card
+    if not _unmount_sd(self, printer_port):
+        self._send_status("flasherror", message="Unable to unmount SD card")
+        return False
+
+    # loop until the mount is available; timeout after 60s
+    count = 1
+    timeout = 60
+    interval = 1
+    sdstarttime = time.time()
+    self._logger.info(u"Waiting for SD card to be available at '{}'".format(lpc1768_path))
+    self._send_status("progress", subtype="waitforsd")
+    while (time.time() < (sdstarttime + timeout) and not os.access(lpc1768_path, os.W_OK)):
+        self._logger.debug(u"Waiting for firmware folder path to become available [{}/{}]".format(count, int(timeout / interval)))
+        count = count + 1
+        time.sleep(interval)
+
+    if not os.access(lpc1768_path, os.W_OK):
+        self._send_status("flasherror", message="Unable to access firmware folder")
+        self._logger.error(u"Firmware folder path is not writeable: {path}".format(path=lpc1768_path))
+        return False
+
+    self._logger.info(u"Firmware update folder '{}' available for writing after {} seconds".format(lpc1768_path, round((time.time() - sdstarttime),0)))
+
+    target_path = lpc1768_path + '/firmware.bin'
+    self._logger.info(u"Copying firmware to update folder '{}' -> '{}'".format(firmware, target_path))
+
+    self._send_status("progress", subtype="copying")
+
+    try:
+        shutil.copyfile(firmware, target_path)
+    except:
+        self._logger.exception(u"Flashing failed. Unable to copy file.")
+        self._send_status("flasherror", message="Unable to copy firmware file to firmware folder")
+        return False
+
+    self._send_status("progress", subtype="unmounting")
+
+    # Sync the filesystem to flush writes
+    self._logger.info(u"Synchronizing cached writes to SD card")
+    try:
+        r = os.system('sync')
+    except:
+        e = sys.exc_info()[0]
+        self._logger.error("Error executing 'sync' command")
+        return False
+    time.sleep(1)
+
+    unmount_command = self._settings.get(["lpc1768_unmount_command"])
+    if unmount_command:
+        unmount_command = unmount_command.replace("{mountpoint}", lpc1768_path)
+
+        self._logger.info(u"Unmounting SD card: '{}'".format(unmount_command))
+        try:
+            p = subprocess.Popen(unmount_command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+            out, err = p.communicate()
+            r = p.returncode
+
+        except:
+            e = sys.exc_info()[0]
+            self._logger.error("Error executing unmount command '{}'".format(unmount_command))
+            self._logger.error("{}".format(str(e)))
+            self._send_status("flasherror", message="Unable to unmount SD card")
+            return False
+
+        if r != 0:
+            if err.strip().endswith("not mounted."):
+                self._logger.info("{}".format(err.strip()))
+            else:
+                self._logger.error("Error executing unmount command '{}'".format(unmount_command))
+                self._logger.error("{}".format(err.strip()))
+                self._send_status("flasherror", message="Unable to unmount SD card")
+                return False
+
+    self._send_status("progress", subtype="boardreset")
+    self._logger.info(u"Firmware update reset: attempting to reset the board")
+    if not _reset_lpc1768(self, printer_port):
+        self._logger.error(u"Reset failed")
+        return False
+
+    return True
+
+def _reset_board(self, printer_port=None):
+    assert(printer_port is not None)
+    self._logger.info(u"Resetting LPC1768 at '{port}'".format(port=printer_port))
+
+    # Configure the port
+    try:
+        os.system('stty -F ' + printer_port + ' speed 115200 -echo > /dev/null')
+    except:
+        self._logger.exception(u"Error configuring serial port.")
+        self._send_status("flasherror", message="Board reset failed")
+        return False
+
+    # Smoothie reset command
+    try:
+        os.system('echo reset >> ' + printer_port)
+    except:
+        self._logger.exception(u"Error sending Smoothie 'reset' command.")
+        self._send_status("flasherror", message="Board reset failed")
+        return False
+
+    # Marlin reset command
+    try:
+        os.system('echo M997 >> ' + printer_port)
+    except:
+        self._logger.exception(u"Error sending Marlin 'M997' command.")
+        self._send_status("flasherror", message="Board reset failed")
+        return False
+
+    if _wait_for_lpc1768(self, printer_port):
+        return True
+    else:
+        self._logger.error(u"Board reset failed")
+        self._send_status("flasherror", message="Board reset failed")
+        return False
+
+def _wait_for_board(self, printer_port=None):
+    assert(printer_port is not None)
+    self._logger.info(u"Waiting for LPC1768 at '{port}' to reset".format(port=printer_port))
+
+    check_command = 'ls ' + printer_port + ' > /dev/null 2>&1'
+    start = time.time()
+    timeout = 10
+    interval = 0.2
+    count = 1
+    connected = True
+
+    loopstarttime = time.time()
+
+    while (time.time() < (loopstarttime + timeout) and connected):
+        self._logger.debug(u"Waiting for reset to init [{}/{}]".format(count, int(timeout / interval)))
+        count = count + 1
+
+        if not os.system(check_command):
+            connected = True
+            time.sleep(interval)
+
+        else:
+            time.sleep(interval)
+            connected = False
+
+    if connected:
+        self._logger.error(u"Timeout waiting for board reset to init")
+        return False
+
+    self._logger.info(u"LPC1768 at '{port}' is resetting".format(port=printer_port))
+
+    time.sleep(3)
+
+    timeout = 20
+    interval = 0.2
+    count = 1
+    connected = False
+
+    loopstarttime = time.time()
+    while (time.time() < (loopstarttime + timeout) and not connected):
+        self._logger.debug(u"Waiting for reset to complete [{}/{}]".format(count, int(timeout / interval)))
+        count = count + 1
+
+        if not os.system(check_command):
+            connected = True
+            time.sleep(interval)
+
+        else:
+            time.sleep(interval)
+            connected = False
+
+    if not connected:
+        self._logger.error(u"Timeout waiting for board reset to complete")
+        return False
+
+    end = time.time()
+    self._logger.info(u"LPC1768 at '{port}' reset in {duration} seconds".format(port=printer_port, duration=(round((end - start),2))))
+    return True

--- a/octoprint_firmwareupdater/methods/marlinbft.py
+++ b/octoprint_firmwareupdater/methods/marlinbft.py
@@ -4,157 +4,51 @@ import time
 import shutil
 import subprocess
 import sys
+import copy
+import binproto2 as mbp
 
 def _check_marlinbft(self):
-    lpc1768_path = self._settings.get(["lpc1768_path"])
-    pattern = re.compile("^(\/[^\0/]+)+$")
-
-    if not pattern.match(lpc1768_path):
-        self._logger.error(u"Firmware folder path is not valid: {path}".format(path=lpc1768_path))
-        return False
-    elif lpc1768_path is None:
-        self._logger.error(u"Firmware folder path is not set.")
-        return False
-    if not os.path.exists(lpc1768_path):
-        self._logger.error(u"Firmware folder path does not exist: {path}".format(path=lpc1768_path))
-        return False
-    elif not os.path.isdir(lpc1768_path):
-        self._logger.error(u"Firmware folder path is not a folder: {path}".format(path=lpc1768_path))
-        return False
-    else:
-        return True
+    # TODO: Figure out how to check for the Marlin BFT capability
+    return True
 
 def _flash_marlinbft(self, firmware=None, printer_port=None):
     assert(firmware is not None)
     assert(printer_port is not None)
 
-    lpc1768_path = self._settings.get(["lpc1768_path"])
-    working_dir = os.path.dirname(lpc1768_path)
-
-    if self._settings.get_boolean(["lpc1768_preflashreset"]):
-        self._send_status("progress", subtype="boardreset")
-
-        # Sync the filesystem to flush writes
-        self._logger.info(u"Synchronizing cached writes to SD card")
-        try:
-            r = os.system('sync')
-        except:
-            e = sys.exc_info()[0]
-            self._logger.error("Error executing 'sync' command")
-            return False
-        time.sleep(1)
-
-        if os.access(lpc1768_path, os.W_OK):
-            unmount_command = self._settings.get(["lpc1768_unmount_command"])
-            if unmount_command:
-                unmount_command = unmount_command.replace("{mountpoint}", lpc1768_path)
-
-                self._logger.info(u"Unmounting SD card: '{}'".format(unmount_command))
-                try:
-                    p = subprocess.Popen(unmount_command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-                    out, err = p.communicate()
-                    r = p.returncode
-
-                except:
-                    e = sys.exc_info()[0]
-                    self._logger.error("Error executing unmount command '{}'".format(unmount_command))
-                    self._logger.error("{}".format(str(e)))
-                    self._send_status("flasherror", message="Unable to unmount SD card")
-                    return False
-
-                if r != 0:
-                    if err.strip().endswith("not mounted."):
-                        self._logger.info("{}".format(err.strip()))
-                    else:
-                        self._logger.error("Error executing unmount command '{}'".format(unmount_command))
-                        self._logger.error("{}".format(err.strip()))
-                        self._send_status("flasherror", message="Unable to unmount SD card")
-                        return False
-        else:
-            self._logger.info(u"SD card not mounted, skipping unmount")
-
-        self._logger.info(u"Pre-flash reset: attempting to reset the board")
-        if not _reset_lpc1768(self, printer_port):
-            self._logger.error(u"Reset failed")
-            return False
-
-    # Release the SD card
-    if not _unmount_sd(self, printer_port):
-        self._send_status("flasherror", message="Unable to unmount SD card")
-        return False
-
-    # loop until the mount is available; timeout after 60s
-    count = 1
-    timeout = 60
-    interval = 1
-    sdstarttime = time.time()
-    self._logger.info(u"Waiting for SD card to be available at '{}'".format(lpc1768_path))
-    self._send_status("progress", subtype="waitforsd")
-    while (time.time() < (sdstarttime + timeout) and not os.access(lpc1768_path, os.W_OK)):
-        self._logger.debug(u"Waiting for firmware folder path to become available [{}/{}]".format(count, int(timeout / interval)))
-        count = count + 1
-        time.sleep(interval)
-
-    if not os.access(lpc1768_path, os.W_OK):
-        self._send_status("flasherror", message="Unable to access firmware folder")
-        self._logger.error(u"Firmware folder path is not writeable: {path}".format(path=lpc1768_path))
-        return False
-
-    self._logger.info(u"Firmware update folder '{}' available for writing after {} seconds".format(lpc1768_path, round((time.time() - sdstarttime),0)))
-
-    target_path = lpc1768_path + '/firmware.bin'
-    self._logger.info(u"Copying firmware to update folder '{}' -> '{}'".format(firmware, target_path))
-
-    self._send_status("progress", subtype="copying")
+    self._logger.info(u"Transfering file to printer using Marlin BFT '{}' -> /firmware.bin".format(firmware))
+    self._send_status("progress", subtype="sending")
 
     try:
-        shutil.copyfile(firmware, target_path)
+        # Open the binary protocol connection
+        protocol = mbp.Protocol(printer_port, 115200, 512, 1000, self._logger)
+
+        # Make sure temperature auto-reporting is disabled
+        protocol.send_ascii("M155 S0")
+
+        # Connect
+        protocol.connect()
+
+        # Copy the file
+        filetransfer = mbp.FileTransferProtocol(protocol, None)
+        filetransfer.copy(firmware, 'firmware.bin', True, False)
+
+        self._logger.info(u"Transfer complete")
+
+        # Disconnect
+        protocol.disconnect()
+
     except:
-        self._logger.exception(u"Flashing failed. Unable to copy file.")
-        self._send_status("flasherror", message="Unable to copy firmware file to firmware folder")
+        self._logger.exception(u"Flashing failed. Unable to transfer file.")
+        self._send_status("flasherror", message="Unable to transfer firmware file to printer")
         return False
 
-    self._send_status("progress", subtype="unmounting")
-
-    # Sync the filesystem to flush writes
-    self._logger.info(u"Synchronizing cached writes to SD card")
-    try:
-        r = os.system('sync')
-    except:
-        e = sys.exc_info()[0]
-        self._logger.error("Error executing 'sync' command")
-        return False
-    time.sleep(1)
-
-    unmount_command = self._settings.get(["lpc1768_unmount_command"])
-    if unmount_command:
-        unmount_command = unmount_command.replace("{mountpoint}", lpc1768_path)
-
-        self._logger.info(u"Unmounting SD card: '{}'".format(unmount_command))
-        try:
-            p = subprocess.Popen(unmount_command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-            out, err = p.communicate()
-            r = p.returncode
-
-        except:
-            e = sys.exc_info()[0]
-            self._logger.error("Error executing unmount command '{}'".format(unmount_command))
-            self._logger.error("{}".format(str(e)))
-            self._send_status("flasherror", message="Unable to unmount SD card")
-            return False
-
-        if r != 0:
-            if err.strip().endswith("not mounted."):
-                self._logger.info("{}".format(err.strip()))
-            else:
-                self._logger.error("Error executing unmount command '{}'".format(unmount_command))
-                self._logger.error("{}".format(err.strip()))
-                self._send_status("flasherror", message="Unable to unmount SD card")
-                return False
+    finally:
+        if (protocol):
+            protocol.shutdown()
 
     self._send_status("progress", subtype="boardreset")
     self._logger.info(u"Firmware update reset: attempting to reset the board")
-    if not _reset_lpc1768(self, printer_port):
+    if not _reset_board(self, printer_port):
         self._logger.error(u"Reset failed")
         return False
 
@@ -162,7 +56,7 @@ def _flash_marlinbft(self, firmware=None, printer_port=None):
 
 def _reset_board(self, printer_port=None):
     assert(printer_port is not None)
-    self._logger.info(u"Resetting LPC1768 at '{port}'".format(port=printer_port))
+    self._logger.info(u"Resetting printer at '{port}'".format(port=printer_port))
 
     # Configure the port
     try:
@@ -188,7 +82,7 @@ def _reset_board(self, printer_port=None):
         self._send_status("flasherror", message="Board reset failed")
         return False
 
-    if _wait_for_lpc1768(self, printer_port):
+    if _wait_for_board(self, printer_port):
         return True
     else:
         self._logger.error(u"Board reset failed")
@@ -197,7 +91,7 @@ def _reset_board(self, printer_port=None):
 
 def _wait_for_board(self, printer_port=None):
     assert(printer_port is not None)
-    self._logger.info(u"Waiting for LPC1768 at '{port}' to reset".format(port=printer_port))
+    self._logger.info(u"Waiting for printer at '{port}' to reset".format(port=printer_port))
 
     check_command = 'ls ' + printer_port + ' > /dev/null 2>&1'
     start = time.time()
@@ -224,7 +118,7 @@ def _wait_for_board(self, printer_port=None):
         self._logger.error(u"Timeout waiting for board reset to init")
         return False
 
-    self._logger.info(u"LPC1768 at '{port}' is resetting".format(port=printer_port))
+    self._logger.info(u"Printer at '{port}' is resetting".format(port=printer_port))
 
     time.sleep(3)
 
@@ -251,5 +145,5 @@ def _wait_for_board(self, printer_port=None):
         return False
 
     end = time.time()
-    self._logger.info(u"LPC1768 at '{port}' reset in {duration} seconds".format(port=printer_port, duration=(round((end - start),2))))
+    self._logger.info(u"Printer at '{port}' reset in {duration} seconds".format(port=printer_port, duration=(round((end - start),2))))
     return True

--- a/octoprint_firmwareupdater/methods/stm32flash.py
+++ b/octoprint_firmwareupdater/methods/stm32flash.py
@@ -25,7 +25,7 @@ def _check_stm32flash(self):
     else:
         return True
 
-def _flash_stm32flash(self, firmware=None, printer_port=None):
+def _flash_stm32flash(self, firmware=None, printer_port=None, **kwargs):
     assert(firmware is not None)
     assert(printer_port is not None)
 

--- a/octoprint_firmwareupdater/static/js/firmwareupdater.js
+++ b/octoprint_firmwareupdater/static/js/firmwareupdater.js
@@ -18,6 +18,7 @@ $(function() {
         self.showLpc1768Config = ko.observable(false);
         self.showDfuConfig = ko.observable(false);
         self.showStm32flashConfig = ko.observable(false);
+        self.showMarlinBftConfig = ko.observable(false);
         self.showPostflashConfig = ko.observable(false);
         self.showPluginOptions = ko.observable(false);
         self.configEnablePostflashDelay = ko.observable();
@@ -175,36 +176,49 @@ $(function() {
                 self.showLpc1768Config(false);
                 self.showDfuConfig(false);
                 self.showStm32flashConfig(false);
+                self.showMarlinBftConfig(false);
             } else if(value == 'bossac') {
                 self.showAvrdudeConfig(false);
                 self.showBossacConfig(true);
                 self.showLpc1768Config(false);
                 self.showDfuConfig(false);
                 self.showStm32flashConfig(false);
+                self.showMarlinBftConfig(false);
             } else if(value == 'lpc1768'){
                 self.showAvrdudeConfig(false);
                 self.showBossacConfig(false);
                 self.showLpc1768Config(true);
                 self.showStm32flashConfig(false);
                 self.showDfuConfig(false);
+                self.showMarlinBftConfig(false);
             } else if(value == 'dfuprogrammer'){
                 self.showAvrdudeConfig(false);
                 self.showBossacConfig(false);
                 self.showLpc1768Config(false);
                 self.showDfuConfig(true);
                 self.showStm32flashConfig(false);
+                self.showMarlinBftConfig(false);
             } else if(value == 'stm32flash'){
                 self.showAvrdudeConfig(false);
                 self.showBossacConfig(false);
                 self.showLpc1768Config(false);
                 self.showDfuConfig(false);
                 self.showStm32flashConfig(true);
+                self.showMarlinBftConfig(false);
+            } else if(value == 'marlinbft'){
+                self.showAvrdudeConfig(false);
+                self.showBossacConfig(false);
+                self.showLpc1768Config(false);
+                self.showDfuConfig(false);
+                self.showStm32flashConfig(false);
+                self.showMarlinBftConfig(true);
             } else {
                 self.showAvrdudeConfig(false);
                 self.showBossacConfig(false);
                 self.showLpc1768Config(false);
                 self.showDfuConfig(false);
                 self.showStm32flashConfig(false);
+                self.showMarlinBftConfig(false);
             }
          });
 
@@ -442,6 +456,10 @@ $(function() {
                                 }
                                 case "copying": {
                                     message = gettext("Copying firmware to SD card...");
+                                    break;
+                                }
+                                case "sending": {
+                                    message = gettext("Sending firmware to printer...");
                                     break;
                                 }
                                 case "unmounting": {

--- a/octoprint_firmwareupdater/static/js/firmwareupdater.js
+++ b/octoprint_firmwareupdater/static/js/firmwareupdater.js
@@ -76,13 +76,18 @@ $(function() {
         self.configLpc1768Path = ko.observable();
         self.configLpc1768ResetBeforeFlash = ko.observable();
         self.configLpc1768UnmountCommand = ko.observable();
-
         self.lpc1768PathBroken = ko.observable(false);
         self.lpc1768PathOk = ko.observable(false);
         self.lpc1768PathText = ko.observable();
         self.lpc1768PathHelpVisible = ko.computed(function() {
             return self.lpc1768PathBroken() || self.lpc1768PathOk();
         });
+
+        // Config settings for marlinbft
+        self.configMarlinBftWaitAfterConnect = ko.observable();
+        self.configMarlinBftTimeout = ko.observable();
+        self.configMarlinBftProgressLogging = ko.observable();
+        self.marlinbftHasCapability = ko.observable();
 
         // Config settings for dfu-programmer
         self.configDfuMcu = ko.observable();
@@ -145,6 +150,7 @@ $(function() {
                 self.firmwareFileURL("");
             }
 
+            self.marlinbftHasCapability(self.settingsViewModel.settings.plugins.firmwareupdater.marlinbft_hascapability());
             self.pluginVersion(self.settingsViewModel.settings.plugins.firmwareupdater.plugin_version());
         }
 
@@ -291,6 +297,14 @@ $(function() {
             if (self.settingsViewModel.settings.plugins.firmwareupdater.flash_method() == "dfuprogrammer" && !self.settingsViewModel.settings.plugins.firmwareupdater.dfuprog_avrmcu()) {
                 alert = gettext("The AVR MCU type is not selected.");
             }
+            
+            if (self.settingsViewModel.settings.plugins.firmwareupdater.flash_method() == "marlinbft" && !self.printerState.isReady()) {
+                alert = gettext("The printer is not connected.");
+            }
+
+            if (self.settingsViewModel.settings.plugins.firmwareupdater.flash_method() == "marlinbft" && self.printerState.isReady() && !self.marlinbftHasCapability()) {
+                alert = gettext("The printer does not support Binary File Transfer.");
+            }
 
             if (!self.flashPort() &! self.settingsViewModel.settings.plugins.firmwareupdater.flash_method() == "dfuprogrammer") {
                 alert = gettext("The printer port is not selected.");
@@ -351,10 +365,7 @@ $(function() {
                 return;
             }
 
-            console.log(self.settingsViewModel.settings.plugins.firmwareupdater.save_url());
-            console.log(self.firmwareFileURL());
             if (self.settingsViewModel.settings.plugins.firmwareupdater.save_url()) {
-                console.log(self.firmwareFileURL());
                 self.configLastUrl(self.firmwareFileURL());
                 self._saveLastUrl();
             }
@@ -382,128 +393,157 @@ $(function() {
 
             var message;
 
-            if (data.type === "status") {
-                switch (data.status) {
-                    case "flasherror": {
-                        if (data.message) {
-                            message = gettext(data.message);
-                        } else {
-                            message = gettext("Unknown error");
-                        }
-
-                        if (data.subtype) {
-                            switch (data.subtype) {
-                                case "busy": {
-                                    message = gettext("Printer is busy.");
-                                    break;
-                                }
-                                case "port": {
-                                    message = gettext("Printer port is not available.");
-                                    break;
-                                }
-                                case "method": {
-                                    message = gettext("Flash method is not properly configured.");
-                                    break;
-                                }
-                                case "hexfile": {
-                                    message = gettext("Cannot read file to flash.");
-                                    break;
-                                }
-                                case "already_flashing": {
-                                    message = gettext("Already flashing.");
-                                }
+            switch (data.type) {
+                case "capability": {
+                    if (data.capability == "BINARY_FILE_TRANSFER") {
+                        self.marlinbftHasCapability(data.enabled);
+                    }
+                    break;
+                }
+                case "status": {
+                    switch (data.status) {
+                        case "flasherror": {
+                            if (data.message) {
+                                message = gettext(data.message);
+                            } else {
+                                message = gettext("Unknown error");
                             }
-                        }
 
-                        self.showPopup("error", gettext("Flashing failed"), message);
-                        self.isBusy(false);
-                        self.showAlert(false);
-                        self.firmwareFileName("");
-                        if (self.settingsViewModel.settings.plugins.firmwareupdater.save_url()) {
-                            self.firmwareFileURL(self.configLastUrl());
-                        } else {
-                            self.firmwareFileURL("");
-                        }
-                        break;
-                    }
-                    case "success": {
-                        self.showPopup("success", gettext("Flashing successful"), "");
-                        self.isBusy(false);
-                        self.showAlert(false);
-                        self.firmwareFileName("");
-                        if (self.settingsViewModel.settings.plugins.firmwareupdater.save_url()) {
-                            self.firmwareFileURL(self.configLastUrl());
-                        } else {
-                            self.firmwareFileURL("");
-                        }
-                        break;
-                    }
-                    case "progress": {
-                        if (data.subtype) {
-                            switch (data.subtype) {
-                                case "disconnecting": {
-                                    message = gettext("Disconnecting printer...");
-                                    break;
-                                }
-                                case "startingflash": {
-                                    self.isBusy(true);
-                                    message = gettext("Starting flash...");
-                                    break;
-                                }
-                                case "waitforsd": {
-                                    message = gettext("Waiting for SD card to mount on host...");
-                                    break;
-                                }
-                                case "copying": {
-                                    message = gettext("Copying firmware to SD card...");
-                                    break;
-                                }
-                                case "sending": {
-                                    message = gettext("Sending firmware to printer...");
-                                    break;
-                                }
-                                case "unmounting": {
-                                    message = gettext("Unmounting SD card...");
-                                    break;
-                                }
-                                case "writing": {
-                                    message = gettext("Writing memory...");
-                                    break;
-                                }
-                                case "erasing": {
-                                    message = gettext("Erasing memory...");
-                                    break;
-                                }
-                                case "verifying": {
-                                    message = gettext("Verifying memory...");
-                                    break;
-                                }
-                                case "postflashdelay": {
-                                    message = gettext("Post-flash delay...");
-                                    break;
-                                }
-                                case "boardreset": {
-                                        message = gettext("Resetting the board...");
+                            if (data.subtype) {
+                                switch (data.subtype) {
+                                    case "busy": {
+                                        message = gettext("Printer is busy.");
                                         break;
-                                }
-                                case "reconnecting": {
-                                    message = gettext("Reconnecting to printer...");
-                                    break;
+                                    }
+                                    case "port": {
+                                        message = gettext("Printer port is not available.");
+                                        break;
+                                    }
+                                    case "method": {
+                                        message = gettext("Flash method is not properly configured.");
+                                        break;
+                                    }
+                                    case "hexfile": {
+                                        message = gettext("Cannot read file to flash.");
+                                        break;
+                                    }
+                                    case "notconnected": {
+                                        message = gettext("Printer is not connected.");
+                                        break;
+                                    }
+                                    case "nobftcap": {
+                                        message = gettext("Printer does not report support for the Marlin Binary File Transfer protocol.");
+                                        break;
+                                    }
+                                    case "already_flashing": {
+                                        message = gettext("Already flashing.");
+                                    }
                                 }
                             }
-                        }
 
-                        if (message) {
-                            self.progressBarText(message);
+                            self.showPopup("error", gettext("Flashing failed"), message);
+                            self.isBusy(false);
+                            self.showAlert(false);
+                            self.firmwareFileName("");
+                            if (self.settingsViewModel.settings.plugins.firmwareupdater.save_url()) {
+                                self.firmwareFileURL(self.configLastUrl());
+                            } else {
+                                self.firmwareFileURL("");
+                            }
+                            break;
                         }
-                        break;
+                        case "success": {
+                            self.showPopup("success", gettext("Flashing successful"), "");
+                            self.isBusy(false);
+                            self.showAlert(false);
+                            self.firmwareFileName("");
+                            if (self.settingsViewModel.settings.plugins.firmwareupdater.save_url()) {
+                                self.firmwareFileURL(self.configLastUrl());
+                            } else {
+                                self.firmwareFileURL("");
+                            }
+                            break;
+                        }
+                        case "progress": {
+                            if (data.subtype) {
+                                switch (data.subtype) {
+                                    case "disconnecting": {
+                                        message = gettext("Disconnecting printer...");
+                                        break;
+                                    }
+                                    case "startingflash": {
+                                        self.isBusy(true);
+                                        message = gettext("Starting flash...");
+                                        break;
+                                    }
+                                    case "waitforsd": {
+                                        message = gettext("Waiting for SD card to mount on host...");
+                                        break;
+                                    }
+                                    case "copying": {
+                                        message = gettext("Copying firmware to SD card...");
+                                        break;
+                                    }
+                                    case "bftinit": {
+                                        message = gettext("Initializing file transfer protocol...");
+                                        break;
+                                    }
+                                    case "bftconnect": {
+                                        message = gettext("Connecting file transfer protocol...");
+                                        break;
+                                    }
+                                    case "finishing": {
+                                        message = gettext("Finishing up...");
+                                        break;
+                                    }
+                                    case "sending": {
+                                        message = gettext("Sending firmware to printer...");
+                                        break;
+                                    }
+                                    case "unmounting": {
+                                        message = gettext("Unmounting SD card...");
+                                        break;
+                                    }
+                                    case "writing": {
+                                        message = gettext("Writing memory...");
+                                        break;
+                                    }
+                                    case "erasing": {
+                                        message = gettext("Erasing memory...");
+                                        break;
+                                    }
+                                    case "verifying": {
+                                        message = gettext("Verifying memory...");
+                                        break;
+                                    }
+                                    case "postflashdelay": {
+                                        message = gettext("Post-flash delay...");
+                                        break;
+                                    }
+                                    case "boardreset": {
+                                            message = gettext("Resetting the board...");
+                                            break;
+                                    }
+                                    case "reconnecting": {
+                                        message = gettext("Reconnecting to printer...");
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (message) {
+                                self.progressBarText(message);
+                            }
+                            break;
+                        }
+                        case "info": {
+                            self.alertType("alert-info");
+                            self.alertMessage(data.status_description);
+                            self.showAlert(true);
+                            break;
+                        }
                     }
-                    case "info": {
-                        self.alertType("alert-info");
-                        self.alertMessage(data.status_description);
-                        self.showAlert(true);
-                        break;
-                    }
+                    break;
                 }
             }
         };
@@ -578,6 +618,11 @@ $(function() {
                 self.configLpc1768ResetBeforeFlash(self.settingsViewModel.settings.plugins.firmwareupdater.lpc1768_preflashreset());
             }
 
+            // Load the marlinbft settings
+            self.configMarlinBftWaitAfterConnect(self.settingsViewModel.settings.plugins.firmwareupdater.marlinbft_waitafterconnect());
+            self.configMarlinBftTimeout(self.settingsViewModel.settings.plugins.firmwareupdater.marlinbft_timeout());
+            self.configMarlinBftProgressLogging(self.settingsViewModel.settings.plugins.firmwareupdater.marlinbft_progresslogging());
+
             // Load the stm32flash settings
             self.configStm32flashPath(self.settingsViewModel.settings.plugins.firmwareupdater.stm32flash_path());
             self.configStm32flashVerify(self.settingsViewModel.settings.plugins.firmwareupdater.stm32flash_verify());
@@ -637,6 +682,9 @@ $(function() {
                         lpc1768_path: self.configLpc1768Path(),
                         lpc1768_unmount_command: self.configLpc1768UnmountCommand(),
                         lpc1768_preflashreset: self.configLpc1768ResetBeforeFlash(),
+                        marlinbft_waitafterconnect: self.configMarlinBftWaitAfterConnect(),
+                        marlinbft_timeout: self.configMarlinBftTimeout(),
+                        marlinbft_progresslogging: self.configMarlinBftProgressLogging(),
                         enable_preflash_commandline: self.configEnablePreflashCommandline(),
                         preflash_commandline: self.configPreflashCommandline(),
                         enable_postflash_commandline: self.configEnablePostflashCommandline(),

--- a/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
+++ b/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
@@ -86,12 +86,13 @@
                 <div class="control-group">
                     <label class="control-label">{{ _('Flash method') }}</label>
                     <div class="controls">
-	                    <select data-bind="value: configFlashMethod">
+	                    <select style="width:285px;" data-bind="value: configFlashMethod">
                             <option></option>
                             <option value=avrdude>avrdude (Atmel AVR Family)</option>
                             <option value=bossac>bossac (Atmel SAM Family)</option>
                             <option value=dfuprogrammer>dfu-programmer (Atmel AVR with DFU)</option>
                             <option value=lpc1768>lpc176x (LPC176x Boards)</option>
+                            <option value=marlinbft>marlinbft (Marlin Binary File Transfer)</option>
                             <option value=stm32flash>stm32flash (STM32 built-in bootloader)</option>
                         </select>
                     </div>
@@ -138,6 +139,7 @@
                             </select>
                         </div>
                     </div>
+                    <hr>
                 </div>
                 <!-- end avrdude options -->
 
@@ -153,6 +155,7 @@
                             <span class="help-block" data-bind="visible: bossacPathBroken() || bossacPathOk, text: bossacPathText"></span>
                         </div>
                     </div>
+                    <hr>
                 </div>
                 <!-- end bossac options -->
 
@@ -168,8 +171,18 @@
                             <span class="help-block" data-bind="visible: lpc1768PathBroken() || lpc1768PathOk, text: lpc1768PathText"></span>
                         </div>
                     </div>
+                    <hr>
                 </div>
                 <!-- end lpc1768 options -->
+
+                <!-- marlinbft options for -->
+                <div data-bind="visible: showMarlinBftConfig">
+                    <div>
+                        <p>Here there be dragons!</p>
+                    </div>
+                    <hr>
+                </div>
+                <!-- end marlinbft options -->
 
                 <!-- dfu-programmer options -->
                 <div data-bind="visible: showDfuConfig">
@@ -193,6 +206,7 @@
                             <span class="help-block" data-bind="visible: dfuPathBroken() || dfuPathOk, text: dfuPathText"></span>
                         </div>
                     </div>
+                    <hr>
                 </div>
                 <!-- end avrdude options -->
 
@@ -208,9 +222,10 @@
                             <span class="help-block" data-bind="visible: stm32flashPathBroken() || stm32flashPathOk, text: stm32flashPathText"></span>
                         </div>
                     </div>
+                    <hr>
                 </div>
                 <!-- end stm32flash options -->
-                <hr>
+
                 <!-- advanced options -->
                 <div data-bind="visible: !showAdvancedConfig() && (showAvrdudeConfig() || showBossacConfig() || showLpc1768Config() || showDfuConfig() || showStm32flashConfig())">
                     <label data-bind="click: toggleAdvancedConfig" >

--- a/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
+++ b/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
@@ -178,7 +178,9 @@
                 <!-- marlinbft options for -->
                 <div data-bind="visible: showMarlinBftConfig">
                     <div>
-                        <p>Here there be dragons!</p>
+                        <i class="icon-warning-sign"></i>&nbsp;&nbsp;<h5 style="display: inline-block">Warning!</h5>
+                        <p>The Marlin Binary File Transfer protocol is still in an <a href="https://github.com/MarlinFirmware/Marlin/pull/14817" target="_new">unfinished / experimental state</a>.  Changes in Marlin may break this method at any time.</p>
+                        <p>That said, it works quite well.</p>
                     </div>
                     <hr>
                 </div>
@@ -227,7 +229,7 @@
                 <!-- end stm32flash options -->
 
                 <!-- advanced options -->
-                <div data-bind="visible: !showAdvancedConfig() && (showAvrdudeConfig() || showBossacConfig() || showLpc1768Config() || showDfuConfig() || showStm32flashConfig())">
+                <div data-bind="visible: !showAdvancedConfig() && (showAvrdudeConfig() || showBossacConfig() || showLpc1768Config() || showDfuConfig() || showStm32flashConfig() || showMarlinBftConfig())">
                     <label data-bind="click: toggleAdvancedConfig" >
                         <i class="icon-chevron-right icon-fixed-width"></i>Advanced Flash Method Settings
                     </label>
@@ -343,7 +345,41 @@
                     </div>
                     <!-- Advanced lpc1768 options -->
 
-                     <!-- Advanced dfu-programmer options -->
+                    <!-- Advanced marlinbft options -->
+                    <div data-bind="visible: showMarlinBftConfig">
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Wait after connect') }}</label>
+                            <div class="controls">
+                                <div class="input-append">
+                                    <input type="number" class="input-mini text-right" step=any min="0" max="30" data-bind="value: configMarlinBftWaitAfterConnect">
+                                    <span class="add-on">seconds</span>
+                                </div>
+                                <span class="help-block">{{ _('Some boards reset after getting the command to start binary transfer mode. A value of 3 seconds is normal for when this wait is required.  Default is 0s') }}</span>
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Communication timeout') }}</label>
+                            <div class="controls">
+                                <div class="input-append">
+                                    <input type="number" class="input-mini text-right" step=any min="0" max="10000" data-bind="value: configMarlinBftTimeout">
+                                    <span class="add-on">milliseconds</span>
+                                </div>
+                                <span class="help-block">{{ _('Protocol communication timeout.  Default is 1000ms') }}</span>
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Verbose progress logging') }}</label>
+                            <div class="controls">
+                                <div class="input">
+                                    <input type="checkbox" data-bind="checked: configMarlinBftProgressLogging">
+                                </div>
+                                <span class="help-block">{{ _('Log verbose transfer progress to the OctoPrint log file') }}</span>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Advanced marlinbft options -->
+
+                    <!-- Advanced dfu-programmer options -->
                     <div data-bind="visible: showDfuConfig">
                         <div class="control-group">
                             <label class="control-label">{{ _('Erase command line') }}</label>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_firmwareupdater"
 plugin_name = "OctoPrint-FirmwareUpdater"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.9.0b0"
+plugin_version = "1.8.1b0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_firmwareupdater"
 plugin_name = "OctoPrint-FirmwareUpdater"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.8.0"
+plugin_version = "1.9.0b0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/OctoPrint/OctoPrint-FirmwareUpdater"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["pyserial>=3.5"]
+plugin_requires = ["pyserial>=3.5","marlin-binary-protocol>=0.0.7"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
Add initial support for flashing via SD card using Marlin's experimental binary file transfer protocol.

Relies on the protocol implementation in the [marlin-bft-protocol](https://github.com/CharlesWillis3/marlin-binary-protocol/) library.