### PR TITLE
More BFT

### DIFF
--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -67,6 +67,8 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 		self._console_logger.setLevel(logging.DEBUG)
 		self._console_logger.propagate = False
 
+		self._logger.info("Python binproto2 package installed: {}".format(marlinbft._check_binproto2(self)))
+
 	# Event handler
 	def on_event(self, event, payload):
 		#self._logger.info("Got event: {}".format(event))

--- a/octoprint_firmwareupdater/methods/marlinbft.py
+++ b/octoprint_firmwareupdater/methods/marlinbft.py
@@ -1,15 +1,26 @@
 import os
 import time
-import shutil
-import subprocess
-import sys
-import binproto2 as mbp
+
+binproto2_installed = True
+try:
+    import binproto2 as mbp
+except:
+    binproto2_installed = False
 
 current_baudrate = None
 
+def _check_binproto2(self):
+    global binproto2_installed
+    return binproto2_installed
+
 def _check_marlinbft(self):
-    self._logger.info("Marlin BINARY_FILE_TRANSFER capability is %s" % (self._settings.get_boolean(["marlinbft_hascapability"])))
-    if not self._settings.get_boolean(["marlinbft_hascapability"]):
+    self._logger.info("Python package 'marlin-binary-protocol' is installed: %s" % (_check_binproto2(self)))
+    self._logger.info("Marlin BINARY_FILE_TRANSFER capability is enabled: %s" % (self._settings.get_boolean(["marlinbft_hascapability"])))
+
+    if not _check_binproto2(self):
+        self._logger.error("Python package 'marlin-binary-protocol' is not installed")
+        self._send_status("flasherror", subtype="nobinproto2")
+    elif not self._settings.get_boolean(["marlinbft_hascapability"]):
         self._logger.error("Marlin BINARY_FILE_TRANSFER capability is not supported")
         self._send_status("flasherror", subtype="nobftcap")
         return False

--- a/octoprint_firmwareupdater/static/js/firmwareupdater.js
+++ b/octoprint_firmwareupdater/static/js/firmwareupdater.js
@@ -445,6 +445,10 @@ $(function() {
                                         message = gettext("Printer does not report support for the Marlin Binary File Transfer protocol.");
                                         break;
                                     }
+                                    case "nobinproto2": {
+                                        message = gettext("Python package 'marlin-binary-protocol' is not installed.");
+                                        break;
+                                    }
                                     case "already_flashing": {
                                         message = gettext("Already flashing.");
                                     }

--- a/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
+++ b/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
@@ -468,7 +468,7 @@
                 <!-- End advanced options-->
 
                 <!-- Pre-flash and post-flash settings -->
-                <div data-bind="visible: !showPostflashConfig() && (showAvrdudeConfig() || showBossacConfig() || showLpc1768Config() || showDfuConfig() || showStm32flashConfig())">
+                <div data-bind="visible: !showPostflashConfig() && (showAvrdudeConfig() || showBossacConfig() || showLpc1768Config() || showDfuConfig() || showStm32flashConfig() || showMarlinBftConfig())">
                     <label data-bind="click: togglePostflashConfig" >
                         <i class="icon-chevron-right icon-fixed-width"></i>Pre-Flash and Post-Flash Settings
                     </label>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_firmwareupdater"
 plugin_name = "OctoPrint-FirmwareUpdater"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.8.1b1"
+plugin_version = "1.8.1b2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/OctoPrint/OctoPrint-FirmwareUpdater"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["pyserial>=3.5","marlin-binary-protocol>=0.0.7"]
+plugin_requires = ["pyserial>=3.5"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
Remove installation dependency on marlin-binary-protocol, will have to have the user install it themselves so that they can deal with the Python2/Python3 dependencies.