### PR TITLE
Tell OctoPi users where their virtualenv is in BFT docs

### DIFF
--- a/doc/marlinbft.md
+++ b/doc/marlinbft.md
@@ -28,9 +28,11 @@ Binary File ransfer is an alternative method to transfer the `firmware.bin` file
    
 ## Installation
 ### Marlin Binary Protocol Package
-The plugin currently uses the `marlin-binary-protocol` package to implement the transfer protocol.  This package has dependencies on `heatshrink`, which is hard to install automatically due to compatibility issues with Python2 and Python3.  For this reason the marlin-binary-protocol package and the heatshrink dependency need to be installed manually using `pip`.
+The plugin currently uses the `marlin-binary-protocol` package to implement the transfer protocol.  This package has dependencies on `heatshrink`, which is hard to install automatically due to compatibility issues with Python 2 and Python 3.  For this reason the marlin-binary-protocol package and the heatshrink dependency need to be installed manually using `pip`.
 
-NB: If you are running OctoPrint in a VirtualEnv you need to run the appropriate `pip` commands below inside that environment.  Depending on your system, the command you use to restart OctoPrint may also be different.
+NB: If you are running OctoPrint in a VirtualEnv (as recommended) you need to run the appropriate `pip` commands below inside that environment. For **OctoPi** users, this is `~/oprint/bin/pip` anywhere it says `pip`. 
+
+Depending on your system, the command you use to restart OctoPrint may also be different.
 
 #### Python 2
 1. Install `marlin-binary-protocol` - the dependencies just work
@@ -40,7 +42,7 @@ NB: If you are running OctoPrint in a VirtualEnv you need to run the appropriate
 
    `sudo service octoprint restart`
    
-#### Python3
+#### Python 3
 1. Install a Python 3 compatible version of `heatshrink` to satisfy `marlin-binary-protocol`
 
     `pip3 install https://github.com/p3p/pyheatshrink/releases/download/0.3.3/pyheatshrink-pip.zip`


### PR DESCRIPTION
Not all of them know where the virtualenv is, what virtualenv is, how to use it. Had a couple questions about installing this on discord, so thought I'd update it for you 🙂.