### PR TITLE
Block serial connection during flash

### DIFF
--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -527,6 +527,7 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
             "has_bftcapability": False,
             "has_binproto2package": False,
             "disable_filefilter": False,
+            "prevent_connection_when_flashing": True,
             "profiles": {},
             "_profiles": {
                 "_name": None,
@@ -717,6 +718,14 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
     def bodysize_hook(self, current_max_body_sizes, *args, **kwargs):
         return [("POST", r"/flash", 1000 * 1024)]
 
+    ##~~ Connect hook
+    def handle_connect_hook(self, *args, **kwargs):
+        if self._settings.get_boolean(["prevent_connection_when_flashing"]) and self._flash_thread:
+            self._logger.info("Flash in progress, preventing connection to printer")
+            return True
+        else:
+            return False
+
     ##~~ Update hook
     def update_hook(self):
         return dict(
@@ -773,5 +782,6 @@ def __plugin_load__():
     __plugin_hooks__ = {
         "octoprint.server.http.bodysize": __plugin_implementation__.bodysize_hook,
         "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.update_hook,
-        "octoprint.comm.protocol.firmware.capabilities": __plugin_implementation__.firmware_capability_hook
+        "octoprint.comm.protocol.firmware.capabilities": __plugin_implementation__.firmware_capability_hook,
+        "octoprint.printer.handle_connect": __plugin_implementation__.handle_connect_hook
     }

--- a/octoprint_firmwareupdater/__init__.py
+++ b/octoprint_firmwareupdater/__init__.py
@@ -285,7 +285,7 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
 
                         self._logger.info("Post-flash command '{}' returned: {}".format(postflash_command, r))
 
-                    # Run post-flash gcode
+                    # Set run post-flash gcode flag
                     postflash_gcode = self.get_profile_setting("postflash_gcode")
                     if postflash_gcode is not None and self.get_profile_setting_boolean("enable_postflash_gcode"):
                         self._logger.info(u"Setting run_postflash_gcode flag to true")
@@ -306,6 +306,9 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
                 except:
                     self._logger.exception(u"Could not delete temporary hex file at {}".format(firmware))
 
+        finally:
+            self._flash_thread = None
+
             if self.get_profile_setting_boolean("no_reconnect_after_flash"):
                 self._logger.info("Automatic reconnection is disabled")
             else:
@@ -314,9 +317,6 @@ class FirmwareupdaterPlugin(octoprint.plugin.BlueprintPlugin,
                     self._logger.info("Reconnecting to printer: port={}, baudrate={}, profile={}".format(port, baudrate, profile))
                     self._send_status("progress", subtype="reconnecting")
                     self._printer.connect(port=port, baudrate=baudrate, profile=profile)
-
-        finally:
-            self._flash_thread = None
 
     # Checks for a valid profile in the plugin's settings
     #   Returns True if the settings contain one or more profiles, otherwise false

--- a/octoprint_firmwareupdater/static/js/firmwareupdater.js
+++ b/octoprint_firmwareupdater/static/js/firmwareupdater.js
@@ -13,6 +13,7 @@ $(function() {
         self.configShowNavbarIcon = ko.observable();                    // enable_navbar
         self.configProfilesEnabled = ko.observable();                   // enable_profiles
         self.configDisableFileFilter = ko.observable();
+        self.configPreventConnectionWhenFlashing = ko.observable();
 
         // Observables for profiles
         self.selectedProfileIndex = ko.observable();                    // _selected_profile
@@ -818,7 +819,7 @@ $(function() {
             self.configProfilesEnabled(self.settingsViewModel.settings.plugins.firmwareupdater.enable_profiles());
             self.configShowNavbarIcon(self.settingsViewModel.settings.plugins.firmwareupdater.enable_navbar());
             self.configSaveUrl(self.settingsViewModel.settings.plugins.firmwareupdater.save_url());
-
+            self.configPreventConnectionWhenFlashing(self.settingsViewModel.settings.plugins.firmwareupdater.prevent_connection_when_flashing());
             self.configDisableFileFilter(self.settingsViewModel.settings.plugins.firmwareupdater.disable_filefilter());
             self.marlinbftHasBinProto2Package(self.settingsViewModel.settings.plugins.firmwareupdater.has_binproto2package());
             self.marlinbftHasCapability(self.settingsViewModel.settings.plugins.firmwareupdater.has_bftcapability());
@@ -1035,6 +1036,7 @@ $(function() {
                         enable_profiles: self.configProfilesEnabled(),
                         save_url: self.configSaveUrl(),
                         disable_filefilter: self.configDisableFileFilter(),
+                        prevent_connection_when_flashing: self.configPreventConnectionWhenFlashing(),
                         profiles: profiles,
                     }
                 }

--- a/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
+++ b/octoprint_firmwareupdater/templates/firmwareupdater_settings.jinja2
@@ -797,6 +797,15 @@
                                 <span class="help-block">{{ _('Disable the file extension filters when selecting a file for \'Flash from file\'.') }}</span>
                             </div>
                         </div>
+                        <div class="control-group">
+                            <label class="control-label">{{ _('Prevent connection when flashing') }}</label>
+                            <div class="controls">
+                                <div class="input">
+                                    <input type="checkbox" data-bind="checked: configPreventConnectionWhenFlashing">
+                                </div>
+                                <span class="help-block">{{ _('Block OctoPring serial connections when a firmware update is in progress. Requires OctoPrint >=1.6.0.') }}</span>
+                            </div>
+                        </div>
                     </form>
                 </div>
                 <!-- End Plugin Options Tab -->

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_firmwareupdater"
 plugin_name = "OctoPrint-FirmwareUpdater"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.11.0b3"
+plugin_version = "1.11.0b4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Use the new hook in OctoPrint 1.6.0 (https://github.com/OctoPrint/OctoPrint/issues/3984) to prevent connections while flash is in progress.