### PR TITLE
Add Prusa MK3 to list of  ATmega 8-bit examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The plugin supports a variety of boards, based on the MCU (processor) they have:
 
 | Description | Examples | Flash Method |
 | --- | --- | --- |
-| Atmel ATmega 8-bit MCUs | RAMPS, Sanguinololu, Melzi, Anet, Creality, Ender, Prusa MMU, Prusa CW1 many others | [avrdude](doc/avrdude.md) |
+| Atmel ATmega 8-bit MCUs | RAMPS, Sanguinololu, Melzi, Anet, Creality, Ender, Prusa MK3, Prusa MMU, Prusa CW1 many others | [avrdude](doc/avrdude.md) |
 | Atmel AT90USB 8-bit MCUs | Printrboard | [dfuprog](doc/dfuprog.md) |
 | NXP LPC176x 32-bit MCUs | MKS SBASE, SKR v1.1, v1.3, v1.4, v1.4 Turbo etc. | [lpc176x](doc/lpc176x.md) or [marlinbft](doc/marlinbft.md) |
 | Atmel SAM 32-bit MCUs | Arduino DUE, etc. | [bossac](doc/bossac.md) |


### PR DESCRIPTION
At first I thought maybe only the Prusa MMU accessory was supported, but not the core Prusa MK3 printer itself. Listing this printer explicitly here would eliminate a source of user confusion. Al