### PR TITLE
Clearer specifications for MCU/programmer combination for Prusa MK3

### DIFF
--- a/doc/avrdude.md
+++ b/doc/avrdude.md
@@ -50,7 +50,7 @@ Typical MCU/programmer combinations are:
 | AVR MCU | Programmer | Example Board |
 | --- | --- | --- |
 | Atmega1284p | arduino | Anet A series, most Creality boards, Ender, etc. |
-| Atmega2560 | wiring | Creality CR-10 Max, RAMPS, RAMbo, etc. |
+| Atmega2560 | wiring | Creality CR-10 Max, RAMPS, Prusa MK3 (RAMbo), etc. |
 | Atmega644p | arduino | Sanguinololu, Melzi |
 | Atmega32u4 | avr109 | Prusa MMU, Prusa CW1 |
 


### PR DESCRIPTION
Initially, I couldn't find the correct combination as I had used the Prusa MMU combination, which failed every time. Only after looking at the prusa3d forum did I realise that the settings for the Rambo should be used. Hopefully, this change could make it clearer to MK3 users without a MMU for which combination to use.